### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/modules/sfp_intelx.py
+++ b/modules/sfp_intelx.py
@@ -251,7 +251,9 @@ class sfp_intelx(SpiderFootPlugin):
                 e = SpiderFootEvent(evt, val, self.__name__, event)
                 self.notifyListeners(e)
 
-        if "public.intelx.io" in self.opts['base_url'] or eventName != "INTERNET_NAME":
+        from urllib.parse import urlparse
+        parsed_url = urlparse(self.opts['base_url'])
+        if parsed_url.hostname == "public.intelx.io" or eventName != "INTERNET_NAME":
             return
 
         data = self.query(eventData, "phonebook")

--- a/modules/sfp_tool_trufflehog.py
+++ b/modules/sfp_tool_trufflehog.py
@@ -15,6 +15,7 @@ import sys
 import json
 import os
 from subprocess import PIPE, Popen, TimeoutExpired
+from urllib.parse import urlparse
 
 from spiderfoot import SpiderFootPlugin, SpiderFootEvent
 
@@ -93,23 +94,23 @@ class sfp_tool_trufflehog(SpiderFootPlugin):
             return
 
         if eventName == "SOCIAL_MEDIA":
-            if "github.com/" in eventData.lower() or "gitlab.com/" in eventData.lower() or "bitbucket.org/" in eventData.lower():
-                try:
-                    url = eventData.split(": ")[1].replace("<SFURL>", "").replace("</SFURL>", "")
-                except BaseException:
-                    self.debug("Unable to extract repository URL, skipping.")
+            try:
+                url = eventData.split(": ")[1].replace("<SFURL>", "").replace("</SFURL>", "")
+                hostname = urlparse(url).hostname
+                if hostname not in ["github.com", "gitlab.com", "bitbucket.org"]:
                     return
-            else:
+            except BaseException:
+                self.debug("Unable to extract repository URL, skipping.")
                 return
 
         if eventName == "PUBLIC_CODE_REPO" and self.opts['allrepos']:
-            if "github.com/" in eventData.lower() or "gitlab.com/" in eventData.lower() or "bitbucket.org/" in eventData.lower():
-                try:
-                    url = eventData.split("\n")[1].replace("URL: ", "")
-                except BaseException:
-                    self.debug("Unable to extract repository URL, skipping.")
+            try:
+                url = eventData.split("\n")[1].replace("URL: ", "")
+                hostname = urlparse(url).hostname
+                if hostname not in ["github.com", "gitlab.com", "bitbucket.org"]:
                     return
-            else:
+            except BaseException:
+                self.debug("Unable to extract repository URL, skipping.")
                 return
 
         if not url:


### PR DESCRIPTION
Potential fix for [https://github.com/poppopjmp/spiderfoot/security/code-scanning/5](https://github.com/poppopjmp/spiderfoot/security/code-scanning/5)

To fix the problem, we need to parse the URL and check the host value to ensure it matches the allowed host correctly. This can be done using the `urlparse` function from the `urllib.parse` module. We will extract the hostname from the URL and then check if it matches the allowed host.

1. Import the `urlparse` function from the `urllib.parse` module.
2. Parse the URL using `urlparse` to extract the hostname.
3. Check if the hostname matches the allowed host (`public.intelx.io`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
