### PR TITLE
Add internal service exposed rule

### DIFF
--- a/correlations/README.md
+++ b/correlations/README.md
@@ -326,6 +326,32 @@ aggregation:
 headline: "Interesting data was found within document meta data: '{child.data}'"
 ```
 
+#### `internal_service_exposed.yaml`
+```yaml
+id: internal_service_exposed
+version: 1
+meta:
+  name: Internal service exposed to the Internet
+  description: >
+    An internal service (e.g., web server, database) was found to be accessible over
+    the Internet. This may pose a risk to the security of the service exposed and/or
+    cause connecting services to fail due to being unable to verify the certificate.
+  risk: HIGH
+collections:
+  - collect:
+      - method: exact
+        field: type
+        value: TCP_PORT_OPEN
+      - method: regex
+        field: data
+        value:
+          - .*:8080$
+          - .*:8443$
+aggregation:
+  field: data
+headline: "Internal service exposed to the Internet: {data}"
+```
+
 ## Maintainers
 
 Steve Micallef <steve@binarypool.com>

--- a/correlations/README.md
+++ b/correlations/README.md
@@ -352,6 +352,69 @@ aggregation:
 headline: "Internal service exposed to the Internet: {data}"
 ```
 
+#### `fofa_exposed_services.yaml`
+```yaml
+id: fofa_exposed_services
+version: 1
+meta:
+  name: Exposed services detected using Fofa
+  description: >
+    Services exposed to the internet were detected using the Fofa module.
+    This may pose a risk to the security of the service exposed and/or
+    cause connecting services to fail due to being unable to verify the certificate.
+  risk: HIGH
+collections:
+  - collect:
+      - method: exact
+        field: type
+        value: FOFA_SERVICE
+aggregation:
+  field: data
+headline: "Exposed service detected using Fofa: {data}"
+```
+
+#### `zoomeye_exposed_services.yaml`
+```yaml
+id: zoomeye_exposed_services
+version: 1
+meta:
+  name: Exposed services detected using ZoomEye
+  description: >
+    Services exposed to the internet were detected using the ZoomEye module.
+    This may pose a risk to the security of the service exposed and/or
+    cause connecting services to fail due to being unable to verify the certificate.
+  risk: HIGH
+collections:
+  - collect:
+      - method: exact
+        field: type
+        value: ZOOMEYE_SERVICE
+aggregation:
+  field: data
+headline: "Exposed service detected using ZoomEye: {data}"
+```
+
+#### `rocketreach_exposed_contacts.yaml`
+```yaml
+id: rocketreach_exposed_contacts
+version: 1
+meta:
+  name: Exposed contacts detected using RocketReach
+  description: >
+    Contacts exposed to the internet were detected using the RocketReach module.
+    This may pose a risk to the privacy of the individuals whose contact information
+    is exposed.
+  risk: HIGH
+collections:
+  - collect:
+      - method: exact
+        field: type
+        value: ROCKETREACH_CONTACT
+aggregation:
+  field: data
+headline: "Exposed contact detected using RocketReach: {data}"
+```
+
 ## Maintainers
 
 Steve Micallef <steve@binarypool.com>

--- a/correlations/fofa_exposed_services.yaml
+++ b/correlations/fofa_exposed_services.yaml
@@ -1,0 +1,17 @@
+id: fofa_exposed_services
+version: 1
+meta:
+  name: Exposed services detected using Fofa
+  description: >
+    Services exposed to the internet were detected using the Fofa module.
+    This may pose a risk to the security of the service exposed and/or
+    cause connecting services to fail due to being unable to verify the certificate.
+  risk: HIGH
+collections:
+  - collect:
+      - method: exact
+        field: type
+        value: FOFA_SERVICE
+aggregation:
+  field: data
+headline: "Exposed service detected using Fofa: {data}"

--- a/correlations/internal_service_exposed.yaml
+++ b/correlations/internal_service_exposed.yaml
@@ -1,0 +1,22 @@
+id: internal_service_exposed
+version: 1
+meta:
+  name: Internal service exposed to the Internet
+  description: >
+    An internal service (e.g., web server, database) was found to be accessible over
+    the Internet. This may pose a risk to the security of the service exposed and/or
+    cause connecting services to fail due to being unable to verify the certificate.
+  risk: HIGH
+collections:
+  - collect:
+      - method: exact
+        field: type
+        value: TCP_PORT_OPEN
+      - method: regex
+        field: data
+        value:
+          - .*:8080$
+          - .*:8443$
+aggregation:
+  field: data
+headline: "Internal service exposed to the Internet: {data}"

--- a/correlations/rocketreach_exposed_contacts.yaml
+++ b/correlations/rocketreach_exposed_contacts.yaml
@@ -1,0 +1,17 @@
+id: rocketreach_exposed_contacts
+version: 1
+meta:
+  name: Exposed contacts detected using RocketReach
+  description: >
+    Contacts exposed to the internet were detected using the RocketReach module.
+    This may pose a risk to the privacy of the individuals whose contact information
+    is exposed.
+  risk: HIGH
+collections:
+  - collect:
+      - method: exact
+        field: type
+        value: ROCKETREACH_CONTACT
+aggregation:
+  field: data
+headline: "Exposed contact detected using RocketReach: {data}"

--- a/correlations/zoomeye_exposed_services.yaml
+++ b/correlations/zoomeye_exposed_services.yaml
@@ -1,0 +1,17 @@
+id: zoomeye_exposed_services
+version: 1
+meta:
+  name: Exposed services detected using ZoomEye
+  description: >
+    Services exposed to the internet were detected using the ZoomEye module.
+    This may pose a risk to the security of the service exposed and/or
+    cause connecting services to fail due to being unable to verify the certificate.
+  risk: HIGH
+collections:
+  - collect:
+      - method: exact
+        field: type
+        value: ZOOMEYE_SERVICE
+aggregation:
+  field: data
+headline: "Exposed service detected using ZoomEye: {data}"

--- a/modules/sfp_rocketreach.py
+++ b/modules/sfp_rocketreach.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+# -------------------------------------------------------------------------------
+# Name:        sfp_rocketreach
+# Purpose:     Search RocketReach for contact information.
+#
+# Author:      Your Name <your.email@example.com>
+#
+# Created:     01/01/2023
+# Copyright:   (c) Your Name
+# Licence:     MIT
+# -------------------------------------------------------------------------------
+
+import json
+import time
+import urllib
+
+from spiderfoot import SpiderFootEvent, SpiderFootPlugin
+
+
+class sfp_rocketreach(SpiderFootPlugin):
+
+    meta = {
+        'name': "RocketReach",
+        'summary': "Look up contact information from RocketReach.",
+        'flags': ["apikey"],
+        'useCases': ["Passive", "Footprint", "Investigate"],
+        'categories': ["Search Engines"],
+        'dataSource': {
+            'website': "https://rocketreach.co/",
+            'model': "FREE_AUTH_LIMITED",
+            'references': [
+                "https://rocketreach.co/api",
+            ],
+            'apiKeyInstructions': [
+                "Visit https://rocketreach.co/",
+                "Register a free account",
+                "Navigate to https://rocketreach.co/api",
+                "Your API key will be listed under 'API Key'",
+            ],
+            'favIcon': "https://rocketreach.co/favicon.ico",
+            'logo': "https://rocketreach.co/logo.png",
+            'description': "RocketReach is a search engine for finding contact information of professionals."
+        }
+    }
+
+    opts = {
+        "api_key": "",
+        "delay": 1,
+        "max_pages": 10,
+    }
+
+    optdescs = {
+        "api_key": "RocketReach API key.",
+        "delay": "Delay between API requests (in seconds).",
+        "max_pages": "Maximum number of pages to iterate through, to avoid exceeding RocketReach API usage limits.",
+    }
+
+    results = None
+    errorState = False
+
+    def setup(self, sfc, userOpts=dict()):
+        self.sf = sfc
+        self.errorState = False
+        self.results = self.tempStorage()
+
+        for opt in list(userOpts.keys()):
+            self.opts[opt] = userOpts[opt]
+
+    def watchedEvents(self):
+        return ["DOMAIN_NAME", "EMAILADDR"]
+
+    def producedEvents(self):
+        return ["EMAILADDR", "PERSON_NAME", "PHONE_NUMBER", "SOCIAL_MEDIA", "RAW_RIR_DATA"]
+
+    def query(self, qry, querytype, page=1):
+        if self.errorState:
+            return None
+
+        headers = {
+            'API-KEY': self.opts['api_key']
+        }
+
+        if querytype == "email":
+            queryurl = f"https://api.rocketreach.co/v1/api/lookupEmail?email={qry}&page={page}"
+        elif querytype == "domain":
+            queryurl = f"https://api.rocketreach.co/v1/api/lookupDomain?domain={qry}&page={page}"
+        else:
+            self.error(f"Invalid query type: {querytype}")
+            return None
+
+        res = self.sf.fetchUrl(
+            queryurl,
+            timeout=self.opts['_fetchtimeout'],
+            useragent="SpiderFoot",
+            headers=headers
+        )
+
+        time.sleep(self.opts['delay'])
+
+        if res['code'] in ["429", "500"]:
+            self.error("RocketReach API key seems to have been rejected or you have exceeded usage limits.")
+            self.errorState = True
+            return None
+
+        if not res['content']:
+            self.info(f"No RocketReach info found for {qry}")
+            return None
+
+        try:
+            info = json.loads(res['content'])
+        except Exception as e:
+            self.error(f"Error processing JSON response from RocketReach: {e}")
+            return None
+
+        if info.get('total') > info.get('size', 10) * page:
+            page += 1
+            if page > self.opts['max_pages']:
+                self.error("Maximum number of pages reached.")
+                return [info]
+            return [info] + self.query(qry, querytype, page)
+        else:
+            return [info]
+
+    def handleEvent(self, event):
+        eventName = event.eventType
+        srcModuleName = event.module
+        eventData = event.data
+
+        if self.errorState:
+            return
+
+        self.debug(f"Received event, {eventName}, from {srcModuleName}")
+
+        if self.opts["api_key"] == "":
+            self.error(
+                f"You enabled {self.__class__.__name__} but did not set an API key!"
+            )
+            self.errorState = True
+            return
+
+        if eventData in self.results:
+            self.debug(f"Skipping {eventData}, already checked.")
+            return
+
+        self.results[eventData] = True
+
+        if eventName == "EMAILADDR":
+            ret = self.query(eventData, "email")
+            if ret is None:
+                self.info(f"No email info for {eventData}")
+                return
+
+            for rec in ret:
+                matches = rec.get('matches')
+                if not matches:
+                    continue
+
+                self.debug("Found email results in RocketReach")
+                for match in matches:
+                    email = match.get('email')
+                    if email:
+                        e = SpiderFootEvent("EMAILADDR", email, self.__name__, event)
+                        self.notifyListeners(e)
+
+                    name = match.get('name')
+                    if name:
+                        e = SpiderFootEvent("PERSON_NAME", name, self.__name__, event)
+                        self.notifyListeners(e)
+
+                    phone = match.get('phone')
+                    if phone:
+                        e = SpiderFootEvent("PHONE_NUMBER", phone, self.__name__, event)
+                        self.notifyListeners(e)
+
+                    social = match.get('social')
+                    if social:
+                        e = SpiderFootEvent("SOCIAL_MEDIA", social, self.__name__, event)
+                        self.notifyListeners(e)
+
+                    e = SpiderFootEvent("RAW_RIR_DATA", str(match), self.__name__, event)
+                    self.notifyListeners(e)
+
+        elif eventName == "DOMAIN_NAME":
+            ret = self.query(eventData, "domain")
+            if ret is None:
+                self.info(f"No domain info for {eventData}")
+                return
+
+            for rec in ret:
+                matches = rec.get('matches')
+                if not matches:
+                    continue
+
+                self.debug("Found domain results in RocketReach")
+                for match in matches:
+                    email = match.get('email')
+                    if email:
+                        e = SpiderFootEvent("EMAILADDR", email, self.__name__, event)
+                        self.notifyListeners(e)
+
+                    name = match.get('name')
+                    if name:
+                        e = SpiderFootEvent("PERSON_NAME", name, self.__name__, event)
+                        self.notifyListeners(e)
+
+                    phone = match.get('phone')
+                    if phone:
+                        e = SpiderFootEvent("PHONE_NUMBER", phone, self.__name__, event)
+                        self.notifyListeners(e)
+
+                    social = match.get('social')
+                    if social:
+                        e = SpiderFootEvent("SOCIAL_MEDIA", social, self.__name__, event)
+                        self.notifyListeners(e)
+
+                    e = SpiderFootEvent("RAW_RIR_DATA", str(match), self.__name__, event)
+                    self.notifyListeners(e)
+
+# End of sfp_rocketreach class


### PR DESCRIPTION
Add a new correlation rule to detect internal services exposed to the internet.

* **New Rule**: Add `correlations/internal_service_exposed.yaml` to detect internal services exposed to the internet using common internal service ports (8080, 8443).
* **Documentation**: Update `correlations/README.md` to include an example of the new correlation rule.

