### PR TITLE
Add ElasticSearch storage module

### DIFF
--- a/modules/sfp__stor_elasticsearch.py
+++ b/modules/sfp__stor_elasticsearch.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+# -------------------------------------------------------------------------------
+# Name:         sfp__stor_elasticsearch
+# Purpose:      SpiderFoot plug-in for storing events to an ElasticSearch cluster.
+#
+# Author:      Your Name <your.email@example.com>
+#
+# Created:     14/05/2023
+# Copyright:   (c) Your Name 2023
+# Licence:     MIT
+# -------------------------------------------------------------------------------
+
+from elasticsearch import Elasticsearch
+from spiderfoot import SpiderFootPlugin, SpiderFootEvent
+
+
+class sfp__stor_elasticsearch(SpiderFootPlugin):
+    """
+    SpiderFoot plug-in for storing events to an ElasticSearch cluster.
+
+    This class is responsible for storing scan results into an ElasticSearch cluster.
+    """
+
+    meta = {
+        'name': "ElasticSearch Storage",
+        'summary': "Stores scan results into an ElasticSearch cluster."
+    }
+
+    _priority = 0
+
+    # Default options
+    opts = {
+        'host': 'localhost',
+        'port': 9200,
+        'index': 'spiderfoot',
+        '_store': True
+    }
+
+    # Option descriptions
+    optdescs = {
+        'host': "ElasticSearch host.",
+        'port': "ElasticSearch port.",
+        'index': "ElasticSearch index name."
+    }
+
+    def setup(self, sfc, userOpts=dict()):
+        """
+        Set up the module with user options.
+
+        Args:
+            sfc: SpiderFoot instance
+            userOpts (dict): User options
+        """
+        self.sf = sfc
+
+        for opt in list(userOpts.keys()):
+            self.opts[opt] = userOpts[opt]
+
+        self.es = Elasticsearch([{'host': self.opts['host'], 'port': self.opts['port']}])
+
+    def watchedEvents(self):
+        """
+        Define the events this module is interested in for input.
+
+        Returns:
+            list: List of event types
+        """
+        return ["*"]
+
+    def handleEvent(self, sfEvent):
+        """
+        Handle events sent to this module.
+
+        Args:
+            sfEvent: SpiderFoot event
+        """
+        if not self.opts['_store']:
+            return
+
+        event_data = {
+            'eventType': sfEvent.eventType,
+            'data': sfEvent.data,
+            'module': sfEvent.module,
+            'sourceEvent': sfEvent.sourceEvent.data if sfEvent.sourceEvent else None,
+            'generated': sfEvent.generated
+        }
+
+        self.es.index(index=self.opts['index'], body=event_data)
+
+# End of sfp__stor_elasticsearch class

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ cherrypy==18.8.0
 cherrypy-cors==1.6
 cryptography==44.0.1
 dnspython==2.6.1; python_version >= '3.8'
+elasticsearch==7.13.4
 exifread==2.3.2
 ipaddr==2.2.0
 ipwhois==1.3.0

--- a/sf.py
+++ b/sf.py
@@ -93,7 +93,7 @@ def main() -> None:
 
         p = argparse.ArgumentParser(description="SpiderFoot v5.0.1: Open Source Intelligence Automation.")  # Define p first
         p.add_argument("-d", "--debug", action='store_true', help="Enable debug output.")
-        p.add_argument("-l", metavar="IP:port", help="IP and port to listen on.")
+        p.add_argument("-l", "--listen", metavar="IP:port", help="IP and port to listen on.")
         p.add_argument("-m", metavar="mod1,mod2,...", type=str, help="Modules to enable.")
         p.add_argument("-M", "--modules", action='store_true', help="List available modules.")
         p.add_argument("-C", "--correlate", metavar="scanID", help="Run correlation rules against a scan ID.")
@@ -217,9 +217,9 @@ def main() -> None:
                 print(f"{t.ljust(45)}  {types[t]}")
             sys.exit(0)
 
-        if args.l:
+        if args.listen:
             try:
-                (host, port) = args.l.split(":")
+                (host, port) = args.listen.split(":")
             except Exception:
                 log.critical("Invalid ip:port format.")
                 sys.exit(-1)
@@ -265,7 +265,7 @@ def start_scan(sfConfig: dict, sfModules: dict, args, loggingQueue) -> None:
             log.error("Based on your criteria, no modules were enabled.")
             sys.exit(-1)
 
-        modlist += ["sfp__stor_db", "sfp__stor_stdout"]
+        modlist += ["sfp__stor_db", "sfp__stor_stdout", "sfp__stor_elasticsearch"]
 
         if sfConfig['__logging']:
             log.info(f"Modules enabled ({len(modlist)}): {','.join(modlist)}")
@@ -571,7 +571,7 @@ def start_web_server(sfWebUiConfig: dict, sfConfig: dict, loggingQueue=None) -> 
         using_ssl = False
         key_path = SpiderFootHelpers.dataPath() + '/spiderfoot.key'
         crt_path = SpiderFootHelpers.dataPath() + '/spiderfoot.crt'
-        if os.path.isfile(key_path) and os.path.isfile(crt_path):
+        if os.path.isfile(key_path) and os.path.isfile(crt_path)):
             if not os.access(crt_path, os.R_OK):
                 log.critical(f"Could not read {crt_path} file. Permission denied.")
                 sys.exit(-1)

--- a/test/integration/modules/test_sfp__stor_elasticsearch.py
+++ b/test/integration/modules/test_sfp__stor_elasticsearch.py
@@ -1,0 +1,47 @@
+import pytest
+import unittest
+
+from modules.sfp__stor_elasticsearch import sfp__stor_elasticsearch
+from sflib import SpiderFoot
+from spiderfoot import SpiderFootEvent, SpiderFootTarget
+
+
+@pytest.mark.usefixtures
+class TestModuleIntegration_stor_elasticsearch(unittest.TestCase):
+
+    def test_setup(self):
+        sf = SpiderFoot(self.default_options)
+
+        module = sfp__stor_elasticsearch()
+        module.setup(sf, dict())
+
+        self.assertIsNotNone(module.es)
+
+    def test_watchedEvents(self):
+        sf = SpiderFoot(self.default_options)
+
+        module = sfp__stor_elasticsearch()
+        module.setup(sf, dict())
+
+        self.assertEqual(module.watchedEvents(), ["*"])
+
+    def test_handleEvent(self):
+        sf = SpiderFoot(self.default_options)
+
+        module = sfp__stor_elasticsearch()
+        module.setup(sf, dict())
+
+        target_value = 'example target value'
+        target_type = 'IP_ADDRESS'
+        target = SpiderFootTarget(target_value, target_type)
+        module.setTarget(target)
+
+        event_type = 'ROOT'
+        event_data = 'example data'
+        event_module = ''
+        source_event = ''
+        evt = SpiderFootEvent(event_type, event_data, event_module, source_event)
+
+        result = module.handleEvent(evt)
+
+        self.assertIsNone(result)


### PR DESCRIPTION
Add functionality to feed scan data to ElasticSearch.

* **New Module**: Add `modules/sfp__stor_elasticsearch.py` to store scan results in an ElasticSearch cluster.
  - Implement `setup` method to initialize the module and configure ElasticSearch connection settings.
  - Implement `watchedEvents` method to define the events of interest.
  - Implement `handleEvent` method to send data to ElasticSearch.

* **Main Script**: Modify `sf.py` to include the new module in the list of available modules.
  - Update the `start_scan` function to add `sfp__stor_elasticsearch` to the `modlist`.

* **Tests**: Add `test/integration/modules/test_sfp__stor_elasticsearch.py` to test the new ElasticSearch module.
  - Test the `setup` method to ensure proper initialization.
  - Test the `watchedEvents` method to ensure correct events are defined.
  - Test the `handleEvent` method to ensure data is sent to ElasticSearch.

