### PR TITLE
Add build script for Node.js web interface

### DIFF
--- a/spiderfoot/static/package.json
+++ b/spiderfoot/static/package.json
@@ -6,5 +6,12 @@
     "jquery": "^3.7.1",
     "sigma": "^3.0.1",
     "tablesorter": "^2.31.3"
+  },
+  "scripts": {
+    "build": "webpack"
+  },
+  "devDependencies": {
+    "webpack": "^5.64.4",
+    "webpack-cli": "^4.9.1"
   }
 }

--- a/spiderfoot/static/webpack.config.js
+++ b/spiderfoot/static/webpack.config.js
@@ -1,0 +1,26 @@
+const path = require('path');
+
+module.exports = {
+  entry: './js/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env', '@babel/preset-react'],
+          },
+        },
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+};


### PR DESCRIPTION
Add a build script and Webpack configuration for the Node.js web interface.

* Modify `spiderfoot/static/package.json` to include a `build` script and add `webpack` and `webpack-cli` as devDependencies.
* Add `spiderfoot/static/webpack.config.js` to configure Webpack for bundling the React components.
* Set the entry point to `./js/index.js` and the output path to `./dist` with the filename `bundle.js`.
* Add rules to handle JavaScript and JSX files using `babel-loader`.

