### PR TITLE
Fix Dockerfile issues and warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,12 @@
 
 FROM debian:bullseye-slim
 ARG REQUIREMENTS=requirements.txt
-RUN apt-get update && apt-get install -y gcc git curl swig libxml2-dev libxslt-dev libjpeg-dev zlib1g-dev libffi-dev libssl-dev cargo rustc python3 python3-venv python3-pip
+RUN apt-get update && apt-get install -y --no-install-recommends gcc=4:10.2.1-1 git=1:2.30.2-1+deb11u2 curl=7.74.0-1.3+deb11u7 swig=4.0.2-1 libxml2-dev=2.9.10+dfsg-6.7+deb11u5 libxslt-dev=1.1.34-4+deb11u1 libjpeg-dev=1:2.0.6-4 zlib1g-dev=1:1.2.11.dfsg-2+deb11u2 libffi-dev=3.3-6 libssl-dev=1.1.1n-0+deb11u3 cargo=0.55.0-1 rustc=1.48.0+dfsg1-2~deb11u1 python3=3.9.2-3 python3-venv=3.9.2-3 python3-pip=20.3.4-4+deb11u1 && rm -rf /var/lib/apt/lists/*
 COPY $REQUIREMENTS requirements.txt ./
 RUN ls
 RUN echo "$REQUIREMENTS"
 RUN pip install -U pip
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Place database and logs outside installation directory
 ENV SPIDERFOOT_DATA /var/lib/spiderfoot
@@ -50,7 +50,7 @@ ENV SPIDERFOOT_LOGS /var/lib/spiderfoot/log
 ENV SPIDERFOOT_CACHE /var/lib/spiderfoot/cache
 
 # Run everything as one command so that only one layer is created
-RUN apt-get update && apt-get install -y libxml2 libxslt1.1 libjpeg62-turbo zlib1g python3 \
+RUN apt-get update && apt-get install -y --no-install-recommends libxml2=2.9.10+dfsg-6.7+deb11u5 libxslt1.1=1.1.34-4+deb11u1 libjpeg62-turbo=1:2.0.6-4 zlib1g=1:1.2.11.dfsg-2+deb11u2 python3=3.9.2-3 \
     && addgroup --system spiderfoot \
     && adduser --system --ingroup spiderfoot --home /home/spiderfoot --shell /usr/sbin/nologin \
                --gecos "SpiderFoot User" spiderfoot \
@@ -64,15 +64,15 @@ RUN apt-get update && apt-get install -y libxml2 libxslt1.1 libjpeg62-turbo zlib
 
 
 # Install tools/dependencies from apt
-RUN apt-get -y update && apt-get -y install nbtscan onesixtyone nmap whatweb bsdmainutils dnsutils coreutils libcap2-bin
+RUN apt-get -y update && apt-get -y install --no-install-recommends nbtscan=1.5.1-1 onesixtyone=0.3.3-1 nmap=7.91+dfsg1+really7.80+dfsg1-2+deb11u1 whatweb=0.5.3-0.1 bsdmainutils=12.1.7+nmu3 dnsutils=1:9.16.22-1~deb11u1 coreutils=8.32-4 libcap2-bin=1:2.44-1 && rm -rf /var/lib/apt/lists/*
 
 # Install Python tools
 
-RUN mkdir /tools
-RUN pip install dnstwist snallygaster trufflehog wafw00f -t /tools
-RUN cd /tools
-RUN git clone --depth 1 https://github.com/testssl/testssl.sh.git
-RUN git clone https://github.com/Tuhinshubhra/CMSeeK && cd CMSeeK && pip install -r requirements.txt && mkdir Results
+RUN mkdir /tools \
+    && pip install --no-cache-dir dnstwist==20200707 snallygaster==0.0.8 trufflehog==2.0.9 wafw00f==2.1.0 -t /tools \
+    && cd /tools \
+    && git clone --depth 1 https://github.com/testssl/testssl.sh.git \
+    && git clone https://github.com/Tuhinshubhra/CMSeeK && cd CMSeeK && pip install --no-cache-dir -r requirements.txt && mkdir Results
 
 ## Enable NMAP into the container to be fully used
 RUN setcap cap_net_raw,cap_net_admin=eip /usr/bin/nmap


### PR DESCRIPTION
Update `Dockerfile` to address various Dockerfile best practices and warnings.

* Pin versions in `apt-get install` commands to specific versions.
* Delete the apt-get lists after installing packages.
* Specify `--no-install-recommends` in `apt-get install` commands.
* Consolidate multiple consecutive `RUN` instructions.
* Use `pip install --no-cache-dir` for pip installations.
* Pin versions in `pip install` commands to specific versions.
* Set `WORKDIR` before `COPY` instructions.
* Use `cd ... || exit` in case `cd` fails.

