### PR TITLE
Fix syntax error in return statement

### DIFF
--- a/spiderfoot/api.py
+++ b/spiderfoot/api.py
@@ -70,7 +70,7 @@ async def list_active_scans():
     try:
         sf = SpiderFoot()
         active_scans = sf.listActiveScans()
-        return {"active_scans": active scans}
+        return {"active_scans": active_scans}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 


### PR DESCRIPTION
Fix invalid syntax in return statement in `spiderfoot/api.py`.

* Add an underscore between `active` and `scans` in the return statement at line 73.
* Ensure the return statement is `return {"active_scans": active_scans}`. 

