### PR TITLE
Add React web app container CI

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,3 +49,41 @@ jobs:
       run: |
         docker run --rm ghcr.io/${{ github.repository }}:${{ github.sha }} sf.py -h
         docker run --rm ghcr.io/${{ github.repository }}:${{ github.sha }} sf.py --version
+
+  build-react-web-app:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Lint Dockerfile with Hadolint
+      uses: hadolint/hadolint-action@v3.1.0
+      with:
+        dockerfile: react-web-interface/Dockerfile
+        failure-threshold: error
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push React web app Docker image
+      id: docker_build_react
+      uses: docker/build-push-action@v5
+      with:
+        context: react-web-interface
+        file: react-web-interface/Dockerfile
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository }}:react-latest
+          ghcr.io/${{ github.repository }}:react-${{ github.sha }}
+
+    - name: Run container tests for React web app
+      run: |
+        docker run --rm ghcr.io/${{ github.repository }}:react-${{ github.sha }} npm run test

--- a/react-web-interface/Dockerfile
+++ b/react-web-interface/Dockerfile
@@ -7,12 +7,9 @@ WORKDIR /app
 COPY . .
 WORKDIR /app/react-web-interface
 # Install the dependencies
-RUN npm install
+RUN npm install --only=dev
 
 # Copy the rest of the application code to the container
-
-# Ensure react-scripts is installed
-RUN npm install react-scripts
 
 # Build the React app
 RUN npm run build

--- a/react-web-interface/Dockerfile
+++ b/react-web-interface/Dockerfile
@@ -1,9 +1,11 @@
 # Use a Node.js base image
 FROM node:14
 
+WORKDIR /app
 # Set the working directory
 # Copy the package.json and package-lock.json files to the container
-
+COPY . .
+WORKDIR /app/react-web-interface
 # Install the dependencies
 RUN npm install
 

--- a/react-web-interface/Dockerfile
+++ b/react-web-interface/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14
 
 # Set the working directory
 WORKDIR /app
-COPY react-web-interface/ .
+COPY ./react-web-interface/ .
 # Copy the package.json and package-lock.json files to the container
 
 # Install the dependencies

--- a/react-web-interface/Dockerfile
+++ b/react-web-interface/Dockerfile
@@ -11,6 +11,8 @@ RUN npm install
 
 # Copy the rest of the application code to the container
 
+# Ensure react-scripts is installed
+RUN npm install react-scripts
 
 # Build the React app
 RUN npm run build

--- a/react-web-interface/Dockerfile
+++ b/react-web-interface/Dockerfile
@@ -3,15 +3,14 @@ FROM node:14
 
 # Set the working directory
 WORKDIR /app
-
+COPY react-web-interface/ .
 # Copy the package.json and package-lock.json files to the container
-COPY package.json package-lock.json ./
 
 # Install the dependencies
 RUN npm install
 
 # Copy the rest of the application code to the container
-COPY . .
+
 
 # Build the React app
 RUN npm run build

--- a/react-web-interface/Dockerfile
+++ b/react-web-interface/Dockerfile
@@ -2,8 +2,6 @@
 FROM node:14
 
 # Set the working directory
-WORKDIR /app
-COPY ./react-web-interface/ .
 # Copy the package.json and package-lock.json files to the container
 
 # Install the dependencies

--- a/react-web-interface/client/package.json
+++ b/react-web-interface/client/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "^5.0.1",
     "axios": "^0.21.1",
     "alertifyjs": "^1.13.1",
     "bootstrap": "^5.3.0",
@@ -13,6 +12,9 @@
     "jquery": "^3.7.1",
     "sigma": "^3.0.1",
     "tablesorter": "^2.31.3"
+  },
+  "devDependencies": {
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/react-web-interface/client/package.json
+++ b/react-web-interface/client/package.json
@@ -37,5 +37,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "package-lock.json": {}
 }

--- a/react-web-interface/client/package.json
+++ b/react-web-interface/client/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "4.0.3",
+    "react-scripts": "^5.0.1",
     "axios": "^0.21.1",
     "alertifyjs": "^1.13.1",
     "bootstrap": "^5.3.0",

--- a/react-web-interface/package.json
+++ b/react-web-interface/package.json
@@ -21,5 +21,6 @@
     "eslint-plugin-react": "^7.22.0"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "package-lock.json": {}
 }

--- a/react-web-interface/package.json
+++ b/react-web-interface/package.json
@@ -14,7 +14,8 @@
     "express": "^4.17.1",
     "axios": "^1.7.9",
     "concurrently": "^5.3.0",
-    "nodemon": "^2.0.7"
+    "nodemon": "^2.0.7",
+    "react-scripts": "^5.0.1"
   },
   "devDependencies": {
     "eslint": "^7.20.0",


### PR DESCRIPTION
Add container build of the React web app to the container CI.

* **New Job `build-react-web-app`**:
  - Add a new job `build-react-web-app` to build the React web app container.
  - Use `docker/setup-buildx-action@v3` to set up Docker Buildx.
  - Use `hadolint/hadolint-action@v3.1.0` to lint the `react-web-interface/Dockerfile`.
  - Use `docker/login-action@v3` to log in to GitHub Container Registry.
  - Use `docker/build-push-action@v5` to build and push the React web app Docker image.
  - Add a step to run container tests for the React web app.

