### PR TITLE
Fix Dockerfile to include package-lock.json

### DIFF
--- a/react-web-interface/client/package.json
+++ b/react-web-interface/client/package.json
@@ -37,5 +37,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "package-lock.json": {}
 }

--- a/react-web-interface/package.json
+++ b/react-web-interface/package.json
@@ -21,5 +21,6 @@
     "eslint-plugin-react": "^7.22.0"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "package-lock.json": {}
 }


### PR DESCRIPTION
Add `package-lock.json` entries to `package.json` files.

* **react-web-interface/client/package.json**
  - Add `"package-lock.json": {}` entry.
* **react-web-interface/package.json**
  - Add `"package-lock.json": {}` entry.

