### PR TITLE
Fix react-scripts not found error in Dockerfile

### DIFF
--- a/react-web-interface/Dockerfile
+++ b/react-web-interface/Dockerfile
@@ -11,6 +11,8 @@ RUN npm install
 
 # Copy the rest of the application code to the container
 
+# Ensure react-scripts is installed
+RUN npm install react-scripts
 
 # Build the React app
 RUN npm run build

--- a/react-web-interface/client/package.json
+++ b/react-web-interface/client/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "4.0.3",
+    "react-scripts": "^5.0.1",
     "axios": "^0.21.1",
     "alertifyjs": "^1.13.1",
     "bootstrap": "^5.3.0",

--- a/react-web-interface/package.json
+++ b/react-web-interface/package.json
@@ -14,7 +14,8 @@
     "express": "^4.17.1",
     "axios": "^1.7.9",
     "concurrently": "^5.3.0",
-    "nodemon": "^2.0.7"
+    "nodemon": "^2.0.7",
+    "react-scripts": "^5.0.1"
   },
   "devDependencies": {
     "eslint": "^7.20.0",


### PR DESCRIPTION
Update the npm build process for the React web interface to complete successfully without errors.

* **Dockerfile Changes**
  - Add `RUN npm install react-scripts` before `RUN npm run build` to ensure `react-scripts` is installed.

* **Package.json Changes**
  - Update `react-web-interface/package.json` to include `react-scripts` dependency with version `^5.0.1`.
  - Update `react-web-interface/client/package.json` to include `react-scripts` dependency with version `^5.0.1`.

