### PR TITLE
Fix npm build script for react-web-interface

### DIFF
--- a/react-web-interface/Dockerfile
+++ b/react-web-interface/Dockerfile
@@ -7,12 +7,9 @@ WORKDIR /app
 COPY . .
 WORKDIR /app/react-web-interface
 # Install the dependencies
-RUN npm install
+RUN npm install --only=dev
 
 # Copy the rest of the application code to the container
-
-# Ensure react-scripts is installed
-RUN npm install react-scripts
 
 # Build the React app
 RUN npm run build

--- a/react-web-interface/client/package.json
+++ b/react-web-interface/client/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "^5.0.1",
     "axios": "^0.21.1",
     "alertifyjs": "^1.13.1",
     "bootstrap": "^5.3.0",
@@ -13,6 +12,9 @@
     "jquery": "^3.7.1",
     "sigma": "^3.0.1",
     "tablesorter": "^2.31.3"
+  },
+  "devDependencies": {
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Update `react-web-interface/client/package.json` and `react-web-interface/Dockerfile` to fix npm build script errors.

* **`react-web-interface/client/package.json`**:
  - Add `react-scripts` to `devDependencies`.
  - Remove `react-scripts` from `dependencies`.

* **`react-web-interface/Dockerfile`**:
  - Remove `RUN npm install react-scripts`.
  - Add `RUN npm install --only=dev` before `RUN npm run build`.

