### PR TITLE
Add LeakCheck plugin to gather breach data

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,18 @@ Whois|Perform a WHOIS look-up on domain names and owned netblocks.|Internal
 [Fofa](https://fofa.so/)|Look up domain, IP address, and other information from Fofa.|Tiered API
 [RocketReach](https://rocketreach.co/)|Look up email addresses, phone numbers, and social media profiles from RocketReach.|Tiered API
 [Netlas](https://netlas.io/)|Look up domain and IP address information from Netlas API.|Tiered API
+[sfp__stor_db.py](https://github.com/poppopjmp/spiderfoot/blob/master/modules/sfp__stor_db.py)|SpiderFoot plug-in for storing events to the local SpiderFoot SQLite database.|Internal
+[sfp__stor_elasticsearch.py](https://github.com/poppopjmp/spiderfoot/blob/master/modules/sfp__stor_elasticsearch.py)|SpiderFoot plug-in for storing events to an ElasticSearch cluster.|Internal
+[sfp__stor_stdout.py](https://github.com/poppopjmp/spiderfoot/blob/master/modules/sfp__stor_stdout.py)|SpiderFoot plug-in for dumping events to standard output.|Internal
+[sfp_abusech.py](https://github.com/poppopjmp/spiderfoot/blob/master/modules/sfp_abusech.py)|Check if a host/domain, IP address or netblock is malicious according to Abuse.ch.|Internal
+[sfp_abuseipdb.py](https://github.com/poppopjmp/spiderfoot/blob/master/modules/sfp_abuseipdb.py)|Check if an IP address is malicious according to AbuseIPDB.com blacklist.|Internal
+[sfp_accounts.py](https://github.com/poppopjmp/spiderfoot/blob/master/modules/sfp_accounts.py)|Look for possible associated accounts on over 500 social and other websites such as Instagram, Reddit, etc.|Internal
+[sfp_adguard_dns.py](https://github.com/poppopjmp/spiderfoot/blob/master/modules/sfp_adguard_dns.py)|Check if a host would be blocked by AdGuard DNS.|Internal
+[sfp_ahmia.py](https://github.com/poppopjmp/spiderfoot/blob/master/modules/sfp_ahmia.py)|Search Tor 'Ahmia' search engine for mentions of the target.|Internal
+[sfp_alienvault.py](https://github.com/poppopjmp/spiderfoot/blob/master/modules/sfp_alienvault.py)|Obtain information from AlienVault Open Threat Exchange (OTX)|Internal
+[sfp_apple_itunes.py](https://github.com/poppopjmp/spiderfoot/blob/master/modules/sfp_apple_itunes.py)|Search Apple iTunes for mobile apps.|Internal
+[sfp_archiveorg.py](https://github.com/poppopjmp/spiderfoot/blob/master/modules/sfp_archiveorg.py)|Identifies historic versions of interesting files/pages from the Wayback Machine.|Internal
+[sfp_azureblobstorage.py](https://github.com/poppopjmp/spiderfoot/blob/master/modules/sfp_azureblobstorage.py)|Search for potential Azure blobs associated with the target and attempt to list their contents.|Internal
 
 ### DOCUMENTATION
 

--- a/correlations/README.md
+++ b/correlations/README.md
@@ -90,15 +90,16 @@ cert_expired.yaml                    host_only_from_certificatetransparency.yaml
 cloud_bucket_open.yaml               http_errors.yaml                             outlier_registrar.yaml
 cloud_bucket_open_related.yaml       human_name_in_whois.yaml                     outlier_webserver.yaml
 data_from_base64.yaml                internal_host.yaml                           remote_desktop_exposed.yaml
-data_from_docmeta.yaml               multiple_malicious.yaml                      root_path_needs_auth.yaml
-database_exposed.yaml                multiple_malicious_affiliate.yaml            stale_host.yaml
-dev_or_test_system.yaml              multiple_malicious_cohost.yaml               strong_affiliate_certs.yaml
-dns_zone_transfer_possible.yaml      name_only_from_pasteleak_site.yaml           strong_similardomain_crossref.yaml
-egress_ip_from_wikipedia.yaml        open_port_version.yaml                       template.yaml
-email_in_multiple_breaches.yaml      outlier_cloud.yaml                           vulnerability_critical.yaml
-email_in_whois.yaml                  outlier_country.yaml                         vulnerability_high.yaml
-email_only_from_pasteleak_site.yaml  outlier_email.yaml                           vulnerability_mediumlow.yaml
-host_only_from_bruteforce.yaml       outlier_hostname.yaml
+data_from_docmeta.yaml               internal_service_exposed.yaml                root_path_needs_auth.yaml
+database_exposed.yaml                multiple_malicious.yaml                      rocketreach_exposed_contacts.yaml
+dev_or_test_system.yaml              multiple_malicious_affiliate.yaml            stale_host.yaml
+dns_zone_transfer_possible.yaml      multiple_malicious_cohost.yaml               strong_affiliate_certs.yaml
+egress_ip_from_wikipedia.yaml        name_only_from_pasteleak_site.yaml           strong_similardomain_crossref.yaml
+email_in_multiple_breaches.yaml      open_port_version.yaml                       template.yaml
+email_in_whois.yaml                  outlier_cloud.yaml                           vulnerability_critical.yaml
+email_only_from_pasteleak_site.yaml  outlier_country.yaml                         vulnerability_high.yaml
+fofa_exposed_services.yaml           outlier_email.yaml                           vulnerability_mediumlow.yaml
+host_only_from_bruteforce.yaml       outlier_hostname.yaml                        zoomeye_exposed_services.yaml
 ```
 ### Rule components
 
@@ -373,27 +374,6 @@ aggregation:
 headline: "Exposed service detected using Fofa: {data}"
 ```
 
-#### `zoomeye_exposed_services.yaml`
-```yaml
-id: zoomeye_exposed_services
-version: 1
-meta:
-  name: Exposed services detected using ZoomEye
-  description: >
-    Services exposed to the internet were detected using the ZoomEye module.
-    This may pose a risk to the security of the service exposed and/or
-    cause connecting services to fail due to being unable to verify the certificate.
-  risk: HIGH
-collections:
-  - collect:
-      - method: exact
-        field: type
-        value: ZOOMEYE_SERVICE
-aggregation:
-  field: data
-headline: "Exposed service detected using ZoomEye: {data}"
-```
-
 #### `rocketreach_exposed_contacts.yaml`
 ```yaml
 id: rocketreach_exposed_contacts
@@ -413,6 +393,27 @@ collections:
 aggregation:
   field: data
 headline: "Exposed contact detected using RocketReach: {data}"
+```
+
+#### `zoomeye_exposed_services.yaml`
+```yaml
+id: zoomeye_exposed_services
+version: 1
+meta:
+  name: Exposed services detected using ZoomEye
+  description: >
+    Services exposed to the internet were detected using the ZoomEye module.
+    This may pose a risk to the security of the service exposed and/or
+    cause connecting services to fail due to being unable to verify the certificate.
+  risk: HIGH
+collections:
+  - collect:
+      - method: exact
+        field: type
+        value: ZOOMEYE_SERVICE
+aggregation:
+  field: data
+headline: "Exposed service detected using ZoomEye: {data}"
 ```
 
 ## Maintainers

--- a/modules/sfp_leakcheck.py
+++ b/modules/sfp_leakcheck.py
@@ -1,0 +1,252 @@
+# -*- coding: utf-8 -*-
+# -------------------------------------------------------------------------------
+# Name:        sfp_leakcheck
+# Purpose:     Gather breach data from LeakCheck API v2.
+#
+# Author:      <the@leakcheck.net>
+#
+# Created:     05-10-2024
+# Copyright:   (c) LeakCheck Security Services LTD
+# Licence:     MIT
+# -------------------------------------------------------------------------------
+
+import json
+import time
+
+from spiderfoot import SpiderFootEvent, SpiderFootPlugin
+
+class sfp_leakcheck(SpiderFootPlugin):
+
+    meta = {
+        'name': "LeakCheck.io",
+        'summary': "Gather breach data from LeakCheck API.",
+        'flags': ["apikey"],
+        'useCases': ["Footprint", "Investigate", "Passive"],
+        'categories': ["Leaks, Dumps and Breaches"],
+        'dataSource': {
+            'website': "https://leakcheck.io/",
+            'model': "COMMERCIAL_ONLY",
+            'references': [
+                "https://wiki.leakcheck.io/en/api"
+            ],
+            'apiKeyInstructions': [
+                "Visit https://leakcheck.io",
+                "Register for an account",
+                "Visit https://leakcheck.io/settings",
+                "Create your API key there"
+            ],
+            'favIcon': "https://leakcheck.io/favicon.ico",
+            'logo': "https://wiki.leakcheck.io/wiki.png",
+            'description': "LeakCheck offers a search engine with a database of more than 9 billion leaked records. Users can search for leaked information using email addresses, usernames, phone numbers, keywords, and domain names. Our goal is to safeguard the data of people and companies."
+        }
+    }
+
+    # Default options
+    opts = {
+        'api_key': '',
+        'pause': 1
+    }
+
+    # Option descriptions
+    optdescs = {
+        'api_key': 'LeakCheck API key.',
+        'pause': 'Number of seconds to wait between each API call.'
+    }
+
+    results = None
+    errorState = False
+
+    def setup(self, sfc, userOpts=dict()):
+        self.sf = sfc
+        self.results = self.tempStorage()
+
+        for opt in list(userOpts.keys()):
+            self.opts[opt] = userOpts[opt]
+
+    # What events is this module interested in for input
+    def watchedEvents(self):
+        return [
+            "DOMAIN_NAME",
+            "EMAILADDR",
+            "PHONE_NUMBER",
+        ]
+
+    # What events this module produces
+    def producedEvents(self):
+        return [
+            'EMAILADDR',
+            'EMAILADDR_COMPROMISED',
+            'USERNAME',
+            'ACCOUNT_EXTERNAL_OWNED_COMPROMISED',
+            'PHONE_NUMBER_COMPROMISED',
+            'IP_ADDRESS',
+            'DATE_HUMAN_DOB',
+            'COUNTRY_NAME',
+            'PASSWORD_COMPROMISED',
+            'HUMAN_NAME',
+            'GEOINFO',
+            'RAW_RIR_DATA'
+        ]
+
+    # Query LeakCheck
+    def query(self, event):
+        if event.eventType == "EMAILADDR":
+            queryString = f"https://leakcheck.io/api/v2/query/{event.data}?type=email"
+        elif event.eventType == "DOMAIN_NAME":
+            queryString = f"https://leakcheck.io/api/v2/query/{event.data}?type=domain"
+        elif event.eventType == "PHONE_NUMBER":
+            queryString = f"https://leakcheck.io/api/v2/query/{event.data.replace('+', '')}?type=phone"
+        else:
+            return None
+
+        headers = {
+            'Accept': 'application/json',
+            'X-API-Key': self.opts['api_key']
+        }
+
+        res = self.sf.fetchUrl(queryString,
+                               headers=headers,
+                               timeout=15,
+                               useragent=self.opts['_useragent'],
+                               verify=True)
+
+        time.sleep(self.opts['pause'])
+
+        if res['code'] == "400":
+            self.error("Invalid API credentials or request.")
+            self.errorState = True
+            return None
+
+        if res['code'] == "401":
+            self.error("Missing or incorrect API key.")
+            self.errorState = True
+            return None
+
+        if res['code'] == "429":
+            self.error("Too many requests performed in a short time. Please wait before trying again.")
+            time.sleep(5)
+            res = self.sf.fetchUrl(queryString, headers=headers, timeout=15, useragent=self.opts['_useragent'], verify=True)
+
+        if res['code'] != "200":
+            self.error("Unable to fetch data from LeakCheck.")
+            self.errorState = True
+            return None
+
+        if res['content'] is None:
+            self.debug('No response from LeakCheck')
+            return None
+
+        try:
+            return json.loads(res['content'])
+        except Exception as e:
+            self.debug(f"Error processing JSON response: {e}")
+            return None
+
+    # Handle events sent to this module
+    def handleEvent(self, event):
+        eventName = event.eventType
+        srcModuleName = event.module
+        eventData = event.data
+
+        if srcModuleName == self.__name__:
+            return
+
+        if eventData in self.results:
+            return
+
+        if self.errorState:
+            return
+
+        self.results[eventData] = True
+
+        self.debug(f"Received event, {eventName}, from {srcModuleName}")
+
+        if self.opts['api_key'] == "":
+            self.error("You enabled sfp_leakcheck but did not set an API key!")
+            self.errorState = True
+            return
+
+        data = self.query(event)
+
+        if not data:
+            return
+
+        if not data.get('found'):
+            self.debug('No breach data found.')
+            return
+
+        for entry in data.get('result', []):
+            email = entry.get('email')
+            username = entry.get('username')
+            phone = entry.get('phone')
+            leakSource = entry.get('source', {}).get('name', 'N/A')
+            breachDate = entry.get('source', {}).get('breach_date', 'Unknown Date')
+            country = entry.get('country', None)
+            ip_address = entry.get('ip', None)
+            dob = entry.get('dob', None)
+            password = entry.get('password', None)
+
+            # Check for human name fields
+            first_name = entry.get('first_name')
+            last_name = entry.get('last_name')
+            middle_name = entry.get('middle_name')
+            name = entry.get('name')
+
+            # Check for geoinfo fields
+            zip_code = entry.get('zip')
+            address = entry.get('address')
+            location = entry.get('location')
+            area = entry.get('area')
+            city = entry.get('city')
+
+            if email:
+                if eventName == "EMAILADDR" and email == eventData:
+                    evt = SpiderFootEvent('EMAILADDR_COMPROMISED', f"{email} [{leakSource} - {breachDate}]", self.__name__, event)
+                    self.notifyListeners(evt)
+                elif eventName == "DOMAIN_NAME":
+                    pevent = SpiderFootEvent("EMAILADDR", email, self.__name__, event)
+                    self.notifyListeners(pevent)
+
+                    evt = SpiderFootEvent('EMAILADDR_COMPROMISED', f"{email} [{leakSource} - {breachDate}]", self.__name__, pevent)
+                    self.notifyListeners(evt)
+
+            if username:
+                evt = SpiderFootEvent('ACCOUNT_EXTERNAL_OWNED_COMPROMISED', f"{username} [{leakSource} - {breachDate}]", self.__name__, event)
+                self.notifyListeners(evt)
+
+            if phone:
+                evt = SpiderFootEvent('PHONE_NUMBER_COMPROMISED', f"{phone} [{leakSource} - {breachDate}]", self.__name__, event)
+                self.notifyListeners(evt)
+
+            if ip_address:
+                evt = SpiderFootEvent('IP_ADDRESS', f"{ip_address} [{leakSource} - {breachDate}]", self.__name__, event)
+                self.notifyListeners(evt)
+
+            if dob:
+                evt = SpiderFootEvent('DATE_HUMAN_DOB', f"{dob} [{leakSource} - {breachDate}]", self.__name__, event)
+                self.notifyListeners(evt)
+
+            if country:
+                evt = SpiderFootEvent('COUNTRY_NAME', f"{country} [{leakSource} - {breachDate}]", self.__name__, event)
+                self.notifyListeners(evt)
+
+            if password:
+                evt = SpiderFootEvent('PASSWORD_COMPROMISED', f"{password} [{leakSource} - {breachDate}]", self.__name__, event)
+                self.notifyListeners(evt)
+
+            # Produce HUMAN_NAME event if name-related fields are found
+            if name or first_name or last_name or middle_name:
+                full_name = ' '.join(filter(None, [name, first_name, middle_name, last_name]))
+                evt = SpiderFootEvent('HUMAN_NAME', f"{full_name} [{leakSource} - {breachDate}]", self.__name__, event)
+                self.notifyListeners(evt)
+
+            # Produce GEOINFO event if geolocation-related fields are found
+            geo_info = ', '.join(filter(None, [address, location, area, city, country, zip_code]))
+            if geo_info:
+                evt = SpiderFootEvent('GEOINFO', f"{geo_info} [{leakSource} - {breachDate}]", self.__name__, event)
+                self.notifyListeners(evt)
+
+            evt = SpiderFootEvent('RAW_RIR_DATA', str(entry), self.__name__, event)
+            self.notifyListeners(evt)
+
+# End of sfp_leakcheck class

--- a/modules/sfp_whoisfreaks.py
+++ b/modules/sfp_whoisfreaks.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+# -------------------------------------------------------------------------------
+# Name:         sfp_whoisfreaks
+# Purpose:      Query whoisfreaks.com using their API.
+#
+# Author:      Mian Fahad
+#
+# Created:     11/10/2023
+# Copyright:   (c) Mian Fahad 2024
+# Licence:     MIT
+# -------------------------------------------------------------------------------
+
+import json
+
+from spiderfoot import SpiderFootEvent, SpiderFootPlugin
+
+
+class sfp_whoisfreaks(SpiderFootPlugin):
+    meta = {
+        'name': "WhoisFreaks",
+        'summary': "Reverse Whois Lookup by owner email or name or company name",
+        'flags': ["slow", "apiKey"],
+        'useCases': ["Investigate", "Passive", "Footprint"],
+        'categories': ["Search Engines"],
+        'dataSource': {
+            'website': "https://whoisfreaks.com/",
+            'model': "FREE_AUTH_LIMITED",
+            'references': [
+                "https://whoisfreaks.com/products/whois-api.html"
+            ],
+            'apiKeyInstructions': [
+                "Visit https://whoisfreaks.com/signup.html",
+                "Register an account.",
+                "The API key will be available on billing dashboard after signup",
+                "500 Free credits upon signup",
+                "select a plan to request beyond this limit",
+                "Visit https://whoisfreaks.com/pricing/api-plans.html",
+
+            ],
+            'favIcon': "https://whoisfreaks.com/images/icons/favicon.ico",
+            'logo': "https://whoisfreaks.com/images/logo.webp",
+            'description': "Search domain names by owner email or name or company name"
+                           " through our Reverse WHOIS lookup API"
+        }
+    }
+
+    # Default options
+    opts = {
+        "api_key": ""
+    }
+
+    # Option descriptions
+    optdescs = {
+        "api_key": "WhoisFreaks account registered API key.",
+    }
+
+    # Be sure to completely clear any class variables in setup()
+    # or you run the risk of data persisting between scan runs.
+
+    results = None
+    errorState = False
+
+    def setup(self, sfc, userOpts=dict()):
+        self.sf = sfc
+        self.results = self.tempStorage()
+
+        for opt in list(userOpts.keys()):
+            self.opts[opt] = userOpts[opt]
+
+    # What events is this module interested in for input
+    def watchedEvents(self):
+        return [
+            "COMPANY_NAME",
+            "HUMAN_NAME",
+            "EMAILADDR",
+            "EMAILADDR_GENERIC",
+        ]
+
+    # What events this module produces
+    def producedEvents(self):
+        return [
+            'AFFILIATE_INTERNET_NAME',
+            'AFFILIATE_DOMAIN_NAME'
+        ]
+
+    # Search WhoisFreaks
+    def query(self, qry, querytype, page=1, accum=None):
+        url = "https://api.whoisfreaks.com/v1.0/whois?whois=reverse&mode=mini&apiKey=" + self.opts['api_key']
+        url += "&" + querytype + "=" + qry + "&page=" + str(page)
+
+        res = self.sf.fetchUrl(url, timeout=self.opts['_fetchtimeout'],
+                               useragent="SpiderFoot")
+
+        if res['code'] in ["401", "429", "413", "412"]:
+            self.error("WhoisFreaks API key seems to have been rejected or you have exceeded usage limits.")
+            self.errorState = True
+            return None
+
+        if res['code'] in ["404", "400"]:
+            self.error("Incorrect paramter or record not found.")
+            self.errorState = True
+            return None
+
+        if res['code'] in ["500", "503", "504"]:
+            self.error("request timed out or server error")
+            self.errorState = True
+            return None
+
+        if res['content'] is None:
+            self.info("No WhoisFreaks info found for " + qry)
+            return None
+
+        try:
+            info = json.loads(res['content'])
+
+            if info.get("total_pages", 1) > 1:
+                if info.get("current_page") < info.get("total_pages"):
+                    if accum:
+                        accum.extend(info.get('whois_domains_historical'))
+                    else:
+                        accum = info.get('whois_domains_historical')
+                    return self.query(qry, querytype, page + 1, accum)
+
+                # We are at the last page
+                accum.extend(info.get('whois_domains_historical', []))
+                return accum
+
+            return info.get('whois_domains_historical', [])
+        except Exception as e:
+            self.error("Error processing JSON response from WhoisFreaks: " + str(e))
+            return None
+
+    # Handle events sent to this module
+    def handleEvent(self, event):
+        eventName = event.eventType
+        srcModuleName = event.module
+        eventData = event.data
+
+        if self.errorState:
+            return
+
+        self.debug(f"Received event, {eventName}, from {srcModuleName}")
+
+        if self.opts['api_key'] == "":
+            self.error("You enabled whoisfreaks but did not set an API key!")
+            self.errorState = True
+            return
+
+        if eventData in self.results:
+            self.debug(f"Skipping {eventData}, already checked.")
+            return
+
+        self.results[eventData] = True
+
+        query_type = None
+        if eventName in "COMPANY_NAME":
+            query_type = "company"
+        elif eventName in "HUMAN_NAME":
+            query_type = "owner"
+        elif eventName in ["EMAILADDR", "EMAILADDR_GENERIC"]:
+            query_type = "email"
+
+        records = self.query(eventData, query_type)
+        if records is not None:
+            for record in records:
+                domain_name = record.get('domain_name')
+                if domain_name:
+                    evt = SpiderFootEvent("AFFILIATE_INTERNET_NAME", domain_name, self.__name__, event)
+                    self.notifyListeners(evt)
+
+                    if self.sf.isDomain(domain_name, self.opts['_internettlds']):
+                        evt = SpiderFootEvent('AFFILIATE_DOMAIN_NAME', domain_name, self.__name__, event)
+                        self.notifyListeners(evt)

--- a/test/integration/modules/test_sfp_whoisfreaks.py
+++ b/test/integration/modules/test_sfp_whoisfreaks.py
@@ -1,0 +1,30 @@
+import unittest
+from modules.sfp_whoisfreaks import sfp_whoisfreaks
+from sflib import SpiderFoot
+
+class TestModuleIntegrationWhoisfreaks(unittest.TestCase):
+
+    def setUp(self):
+        self.sf = SpiderFoot(self.default_options)
+        self.module = sfp_whoisfreaks()
+        self.module.setup(self.sf, dict())
+
+    def test_handleEvent(self):
+        event = SpiderFootEvent("EMAILADDR", "test@example.com", "testModule", None)
+        self.module.handleEvent(event)
+        self.assertFalse(self.module.errorState)
+
+    def test_query(self):
+        result = self.module.query("test@example.com", "email")
+        self.assertIsNotNone(result)
+
+    def test_setup(self):
+        userOpts = {"api_key": "test_api_key"}
+        self.module.setup(self.sf, userOpts)
+        self.assertEqual(self.module.opts["api_key"], "test_api_key")
+
+    def test_watchedEvents(self):
+        self.assertEqual(self.module.watchedEvents(), ["COMPANY_NAME", "HUMAN_NAME", "EMAILADDR", "EMAILADDR_GENERIC"])
+
+    def test_producedEvents(self):
+        self.assertEqual(self.module.producedEvents(), ["AFFILIATE_INTERNET_NAME", "AFFILIATE_DOMAIN_NAME"])


### PR DESCRIPTION
Add `sfp_leakcheck` plugin to gather breach data from LeakCheck API.

* **New Methods**:
  - Add `query` method to handle API requests to LeakCheck.
  - Add `handleEvent` method to process events and generate specified events.

* **Event Handling**:
  - Update `watchedEvents` method to include `EMAILADDR`, `DOMAIN_NAME`, and `PHONE_NUMBER`.
  - Update `producedEvents` method to include `EMAILADDR_COMPROMISED`, `ACCOUNT_EXTERNAL_OWNED_COMPROMISED`, `PHONE_NUMBER_COMPROMISED`, and more.

* **Setup**:
  - Update `setup` method to initialize the plugin with user options.

* **Error Handling**:
  - Add error handling for invalid API credentials, missing API key, and too many requests.

* **Event Notification**:
  - Notify listeners for various events such as `EMAILADDR_COMPROMISED`, `ACCOUNT_EXTERNAL_OWNED_COMPROMISED`, `PHONE_NUMBER_COMPROMISED`, `IP_ADDRESS`, `DATE_HUMAN_DOB`, `COUNTRY_NAME`, `PASSWORD_COMPROMISED`, `HUMAN_NAME`, `GEOINFO`, and `RAW_RIR_DATA`.

