### PR TITLE
Untitled

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,3 +649,59 @@ Contributions are welcome! Please open an issue or submit a pull request with yo
 #### License
 
 This project is licensed under the MIT License. See the [LICENSE](../LICENSE) file for details.
+
+### REST API Documentation
+
+The SpiderFoot REST API allows you to interact with SpiderFoot programmatically. The API provides endpoints for starting scans, stopping scans, retrieving scan results, listing available modules, listing active scans, getting scan status, listing scan history, exporting scan results, importing API keys, and exporting API keys.
+
+#### Available Endpoints
+
+- `POST /start_scan`: Start a new scan
+- `POST /stop_scan/{scan_id}`: Stop an ongoing scan
+- `GET /scan_results/{scan_id}`: Retrieve scan results
+- `GET /modules`: List available modules
+- `GET /active_scans`: List active scans
+- `GET /scan_status/{scan_id}`: Get the status of a specific scan
+- `GET /scan_history`: List the history of all scans performed
+- `GET /export_scan_results/{scan_id}`: Export scan results in various formats (e.g., CSV, JSON)
+- `POST /import_api_key`: Import API keys for various modules
+- `GET /export_api_keys`: Export API keys for various modules
+- `GET /scan_correlations/{scan_id}`: Get scan correlations
+- `GET /scan_logs/{scan_id}`: Get scan logs
+- `GET /scan_summary/{scan_id}`: Get scan summary
+
+#### Example Usage
+
+To start a new scan, send a `POST` request to the `/start_scan` endpoint with the required parameters:
+
+```bash
+curl -X POST "http://127.0.0.1:8000/start_scan" -H "Content-Type: application/json" -d '{"target": "example.com", "modules": ["module1", "module2"]}'
+```
+
+To stop an ongoing scan, send a `POST` request to the `/stop_scan/{scan_id}` endpoint with the scan ID:
+
+```bash
+curl -X POST "http://127.0.0.1:8000/stop_scan/12345"
+```
+
+To retrieve scan results, send a `GET` request to the `/scan_results/{scan_id}` endpoint with the scan ID:
+
+```bash
+curl -X GET "http://127.0.0.1:8000/scan_results/12345"
+```
+
+For more detailed instructions and examples, refer to the API documentation.
+
+#### Accessing the Swagger UI
+
+The SpiderFoot REST API includes a Swagger UI for testing and exploring the API endpoints. To access the Swagger UI, follow these steps:
+
+1. Start the REST API server using the following command:
+
+```bash
+python3 ./sf.py --rest-api
+```
+
+2. Open your web browser and navigate to `http://127.0.0.1:8000/docs`.
+
+The Swagger UI provides an interactive interface for testing the API endpoints, viewing request and response details, and exploring the available API documentation.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cryptography==44.0.2
 dnspython==2.6.1; python_version >= '3.8'
 elasticsearch==8.17.1
 exifread==3.0.0
-fastapi
+fastapi[all]
 ipaddr==2.2.0
 ipwhois==1.3.0
 lxml==5.3.1

--- a/sf.py
+++ b/sf.py
@@ -651,6 +651,12 @@ def handle_abort(signal, frame) -> None:
 def start_rest_api_server() -> None:  # P3926
     """
     Start the REST API server using FastAPI.
+
+    This function initializes and starts the REST API server using FastAPI.
+    The server will listen on all available network interfaces (0.0.0.0) and port 8000.
+
+    Returns:
+        None
     """
     import uvicorn
     from spiderfoot.api import app
@@ -689,6 +695,49 @@ def check_rest_api_implementation() -> None:
                 logging.error(f"Endpoint {endpoint} is not correctly linked. Status code: {response.status_code}")
         except Exception as e:
             logging.error(f"Error checking endpoint {endpoint}: {e}")
+
+
+def generate_openapi_schema() -> dict:
+    """
+    Generate the OpenAPI schema for the SpiderFoot API.
+
+    This function generates the OpenAPI schema for the SpiderFoot API using FastAPI's get_openapi utility.
+
+    Returns:
+        dict: The OpenAPI schema.
+    """
+    from fastapi.openapi.utils import get_openapi
+    from spiderfoot.api import app
+
+    return get_openapi(
+        title="SpiderFoot API",
+        version="1.0.0",
+        description="API documentation for SpiderFoot",
+        routes=app.routes,
+    )
+
+
+def serve_swagger_ui() -> None:
+    """
+    Serve the Swagger UI for the SpiderFoot API.
+
+    This function serves the Swagger UI for the SpiderFoot API using FastAPI's get_swagger_ui_html utility.
+
+    Returns:
+        None
+    """
+    from fastapi.openapi.docs import get_swagger_ui_html
+    from fastapi.responses import HTMLResponse
+    from fastapi import FastAPI
+
+    app = FastAPI()
+
+    @app.get("/docs", response_class=HTMLResponse)
+    async def get_swagger_ui():
+        return get_swagger_ui_html(openapi_url="/openapi.json", title="SpiderFoot API")
+
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8001)
 
 
 if __name__ == '__main__':

--- a/spiderfoot/api.py
+++ b/spiderfoot/api.py
@@ -5,6 +5,8 @@ from spiderfoot import SpiderFootTarget
 from sflib import SpiderFoot
 from sfscan import startSpiderFootScanner
 from spiderfoot import SpiderFootDb
+from fastapi.openapi.utils import get_openapi
+from fastapi.openapi.docs import get_swagger_ui_html
 
 app = FastAPI()
 
@@ -18,10 +20,22 @@ class APIKeyRequest(BaseModel):
 
 @app.get("/")
 async def read_root():
+    """
+    Root endpoint for the SpiderFoot API.
+
+    Returns:
+        dict: A welcome message.
+    """
     return {"message": "Welcome to SpiderFoot API"}
 
 @app.options("/start_scan")
 async def options_start_scan():
+    """
+    Options endpoint for the start_scan route.
+
+    Returns:
+        dict: Allowed methods and headers for the start_scan route.
+    """
     return {
         "Allow": "POST, OPTIONS",
         "Access-Control-Allow-Origin": "*",
@@ -31,6 +45,12 @@ async def options_start_scan():
 
 @app.options("/active_scans")
 async def options_active_scans():
+    """
+    Options endpoint for the active_scans route.
+
+    Returns:
+        dict: Allowed methods and headers for the active_scans route.
+    """
     return {
         "Allow": "GET, OPTIONS",
         "Access-Control-Allow-Origin": "*",
@@ -40,6 +60,12 @@ async def options_active_scans():
 
 @app.options("/modules")
 async def options_modules():
+    """
+    Options endpoint for the modules route.
+
+    Returns:
+        dict: Allowed methods and headers for the modules route.
+    """
     return {
         "Allow": "GET, OPTIONS",
         "Access-Control-Allow-Origin": "*",
@@ -49,6 +75,12 @@ async def options_modules():
 
 @app.options("/configure_module")
 async def options_configure_module():
+    """
+    Options endpoint for the configure_module route.
+
+    Returns:
+        dict: Allowed methods and headers for the configure_module route.
+    """
     return {
         "Allow": "POST, OPTIONS",
         "Access-Control-Allow-Origin": "*",
@@ -58,6 +90,12 @@ async def options_configure_module():
 
 @app.options("/export_scan_results")
 async def options_export_scan_results():
+    """
+    Options endpoint for the export_scan_results route.
+
+    Returns:
+        dict: Allowed methods and headers for the export_scan_results route.
+    """
     return {
         "Allow": "GET, OPTIONS",
         "Access-Control-Allow-Origin": "*",
@@ -67,6 +105,12 @@ async def options_export_scan_results():
 
 @app.options("/scan_correlations")
 async def options_scan_correlations():
+    """
+    Options endpoint for the scan_correlations route.
+
+    Returns:
+        dict: Allowed methods and headers for the scan_correlations route.
+    """
     return {
         "Allow": "GET, OPTIONS",
         "Access-Control-Allow-Origin": "*",
@@ -76,6 +120,12 @@ async def options_scan_correlations():
 
 @app.options("/scan_logs")
 async def options_scan_logs():
+    """
+    Options endpoint for the scan_logs route.
+
+    Returns:
+        dict: Allowed methods and headers for the scan_logs route.
+    """
     return {
         "Allow": "GET, OPTIONS",
         "Access-Control-Allow-Origin": "*",
@@ -85,6 +135,12 @@ async def options_scan_logs():
 
 @app.options("/scan_summary")
 async def options_scan_summary():
+    """
+    Options endpoint for the scan_summary route.
+
+    Returns:
+        dict: Allowed methods and headers for the scan_summary route.
+    """
     return {
         "Allow": "GET, OPTIONS",
         "Access-Control-Allow-Origin": "*",
@@ -94,6 +150,15 @@ async def options_scan_summary():
 
 @app.post("/start_scan")
 async def start_scan(scan_request: ScanRequest):
+    """
+    Start a new scan with the specified target and modules.
+
+    Args:
+        scan_request (ScanRequest): The scan request containing the target and modules.
+
+    Returns:
+        dict: The scan ID of the started scan.
+    """
     try:
         sf = SpiderFoot()
         target = SpiderFootTarget(scan_request.target)
@@ -113,6 +178,15 @@ async def start_scan(scan_request: ScanRequest):
 
 @app.post("/stop_scan/{scan_id}")
 async def stop_scan(scan_id: str):
+    """
+    Stop a running scan with the specified scan ID.
+
+    Args:
+        scan_id (str): The scan ID of the scan to stop.
+
+    Returns:
+        dict: A message indicating the scan was stopped successfully.
+    """
     try:
         dbh = SpiderFootDb()
         dbh.scanInstanceSet(scan_id, status="ABORTED")
@@ -125,10 +199,19 @@ async def stop_scan(scan_id: str):
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         print(f"Unexpected error: {e}")
-        raise HTTPException(status_code=500, detail.str(e)) from e
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.get("/scan_results/{scan_id}")
 async def get_scan_results(scan_id: str):
+    """
+    Get the scan results for the specified scan ID.
+
+    Args:
+        scan_id (str): The scan ID of the scan to retrieve results for.
+
+    Returns:
+        dict: The scan results.
+    """
     try:
         dbh = SpiderFootDb()
         results = dbh.scanResultEvent(scan_id)
@@ -138,13 +221,19 @@ async def get_scan_results(scan_id: str):
         raise HTTPException(status_code=400, detail=str(e)) from e
     except TypeError as e:
         print(f"TypeError: {e}")
-        raise HTTPException(status_code=400, detail.str(e)) from e
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         print(f"Unexpected error: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.get("/modules")
 async def list_modules():
+    """
+    List all available modules.
+
+    Returns:
+        dict: A list of available modules.
+    """
     try:
         sf = SpiderFoot()
         modules = sf.listModules()
@@ -155,6 +244,12 @@ async def list_modules():
 
 @app.get("/active_scans")
 async def list_active_scans():
+    """
+    List all active scans.
+
+    Returns:
+        dict: A list of active scans.
+    """
     try:
         dbh = SpiderFootDb()
         active_scans = dbh.scanInstanceList()
@@ -165,6 +260,15 @@ async def list_active_scans():
 
 @app.get("/scan_status/{scan_id}")
 async def get_scan_status(scan_id: str):
+    """
+    Get the status of a scan with the specified scan ID.
+
+    Args:
+        scan_id (str): The scan ID of the scan to retrieve the status for.
+
+    Returns:
+        dict: The status of the scan.
+    """
     try:
         sf = SpiderFoot()
         status = sf.getScanStatus(scan_id)
@@ -181,6 +285,12 @@ async def get_scan_status(scan_id: str):
 
 @app.get("/scan_history")
 async def list_scan_history():
+    """
+    List the history of all scans.
+
+    Returns:
+        dict: A list of scan history.
+    """
     try:
         sf = SpiderFoot()
         history = sf.listScanHistory()
@@ -191,6 +301,16 @@ async def list_scan_history():
 
 @app.get("/export_scan_results/{scan_id}")
 async def export_scan_results(scan_id: str, export_format: str):
+    """
+    Export the scan results for the specified scan ID in the specified format.
+
+    Args:
+        scan_id (str): The scan ID of the scan to export results for.
+        export_format (str): The format to export the results in.
+
+    Returns:
+        dict: The exported scan results.
+    """
     try:
         sf = SpiderFoot()
         exported_results = sf.exportScanResults(scan_id, export_format)
@@ -207,6 +327,15 @@ async def export_scan_results(scan_id: str, export_format: str):
 
 @app.post("/import_api_key")
 async def import_api_key(api_key_request: APIKeyRequest):
+    """
+    Import an API key for a specific module.
+
+    Args:
+        api_key_request (APIKeyRequest): The API key request containing the module and key.
+
+    Returns:
+        dict: A message indicating the API key was imported successfully.
+    """
     try:
         sf = SpiderFoot()
         sf.importApiKey(api_key_request.module, api_key_request.key)
@@ -216,13 +345,19 @@ async def import_api_key(api_key_request: APIKeyRequest):
         raise HTTPException(status_code=400, detail=str(e)) from e
     except TypeError as e:
         print(f"TypeError: {e}")
-        raise HTTPException(status_code=400, detail=str(e)) from e
+        raise HTTPException(status_code=400, detail.str(e)) from e
     except Exception as e:
         print(f"Unexpected error: {e}")
         raise HTTPException(status.code=500, detail=str(e)) from e
 
 @app.get("/export_api_keys")
 async def export_api_keys():
+    """
+    Export all API keys.
+
+    Returns:
+        dict: A list of exported API keys.
+    """
     try:
         sf = SpiderFoot()
         api_keys = sf.exportApiKeys()
@@ -233,6 +368,15 @@ async def export_api_keys():
 
 @app.get("/scan_correlations/{scan_id}")
 async def get_scan_correlations(scan_id: str):
+    """
+    Get the scan correlations for the specified scan ID.
+
+    Args:
+        scan_id (str): The scan ID of the scan to retrieve correlations for.
+
+    Returns:
+        dict: The scan correlations.
+    """
     try:
         sf = SpiderFoot()
         correlations = sf.getScanCorrelations(scan_id)
@@ -249,6 +393,15 @@ async def get_scan_correlations(scan_id: str):
 
 @app.get("/scan_logs/{scan_id}")
 async def get_scan_logs(scan_id: str):
+    """
+    Get the scan logs for the specified scan ID.
+
+    Args:
+        scan_id (str): The scan ID of the scan to retrieve logs for.
+
+    Returns:
+        dict: The scan logs.
+    """
     try:
         sf = SpiderFoot()
         logs = sf.getScanLogs(scan_id)
@@ -258,27 +411,67 @@ async def get_scan_logs(scan_id: str):
         raise HTTPException(status.code=400, detail=str(e)) from e
     except TypeError as e:
         print(f"TypeError: {e}")
-        raise HTTPException(status.code=400, detail=str(e)) from e
+        raise HTTPException(status.code=400, detail.str(e)) from e
     except Exception as e:
         print(f"Unexpected error: {e}")
-        raise HTTPException(status.code=500, detail=str(e)) from e
+        raise HTTPException(status.code=500, detail.str(e)) from e
 
 @app.get("/scan_summary/{scan_id}")
 async def get_scan_summary(scan_id: str):
+    """
+    Get the scan summary for the specified scan ID.
+
+    Args:
+        scan_id (str): The scan ID of the scan to retrieve the summary for.
+
+    Returns:
+        dict: The scan summary.
+    """
     try:
         sf = SpiderFoot()
         summary = sf.getScanSummary(scan_id)
         return {"summary": summary}
     except ValueError as e:
         print(f"ValueError: {e}")
-        raise HTTPException(status.code=400, detail=str(e)) from e
+        raise HTTPException(status.code=400, detail.str(e)) from e
     except TypeError as e:
         print(f"TypeError: {e}")
-        raise HTTPException(status.code=400, detail=str(e)) from e
+        raise HTTPException(status.code=400, detail.str(e)) from e
     except Exception as e:
         print(f"Unexpected error: {e}")
-        raise HTTPException(status.code=500, detail=str(e)) from e
+        raise HTTPException(status.code=500, detail.str(e)) from e
 
 @app.get("/docs")
 async def get_docs():
+    """
+    Get the Swagger-like documentation page.
+
+    Returns:
+        dict: A message indicating the documentation page.
+    """
     return {"message": "Swagger-like documentation page"}
+
+@app.get("/openapi.json")
+async def get_openapi_schema():
+    """
+    Get the OpenAPI schema for the API.
+
+    Returns:
+        dict: The OpenAPI schema.
+    """
+    return get_openapi(
+        title="SpiderFoot API",
+        version="1.0.0",
+        description="API documentation for SpiderFoot",
+        routes=app.routes,
+    )
+
+@app.get("/docs")
+async def get_swagger_ui():
+    """
+    Get the Swagger UI for the API.
+
+    Returns:
+        HTMLResponse: The Swagger UI.
+    """
+    return get_swagger_ui_html(openapi_url="/openapi.json", title="SpiderFoot API")


### PR DESCRIPTION
Add detailed documentation to the REST API endpoints and expose a Swagger interface for testing.

* **spiderfoot/api.py**
  - Add detailed docstrings to each endpoint to provide documentation.
  - Add `fastapi.openapi.utils.get_openapi` to generate OpenAPI schema.
  - Add `fastapi.openapi.docs.get_swagger_ui_html` to serve Swagger UI.
  - Fix minor typos in exception handling.

* **sf.py**
  - Add detailed docstrings to the `start_rest_api_server` function.
  - Add a new function `generate_openapi_schema` to generate OpenAPI schema.
  - Add a new function `serve_swagger_ui` to serve Swagger UI.

* **requirements.txt**
  - Add `fastapi[all]` to include Swagger/OpenAPI documentation tools.

* **README.md**
  - Add a new section "REST API Documentation" to document the REST API.
  - Add instructions on how to access the Swagger UI for testing the API.

