### PR TITLE
Initialize SpiderFoot class with configuration options and set up logging

### DIFF
--- a/sfapi.py
+++ b/sfapi.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, HTTPException, BackgroundTasks
 from pydantic import BaseModel
 from typing import List
 from spiderfoot import SpiderFootTarget
-from sflib import SpiderFoot
+from sf import SpiderFoot
 from spiderfoot.db import SpiderFootDb
 from spiderfoot.logger import logListenerSetup, logWorkerSetup
 from fastapi.openapi.utils import get_openapi

--- a/sfapi.py
+++ b/sfapi.py
@@ -3,8 +3,8 @@ from pydantic import BaseModel
 from typing import List
 from spiderfoot import SpiderFootTarget
 from sflib import SpiderFoot
-from sfscan import startSpiderFootScanner
-from spiderfoot import SpiderFootDb
+from spiderfoot.db import SpiderFootDb
+from spiderfoot.logger import logListenerSetup, logWorkerSetup
 from fastapi.openapi.utils import get_openapi
 from fastapi.openapi.docs import get_swagger_ui_html
 import asyncio, logging
@@ -32,6 +32,9 @@ sfConfig_API = {
     '_socks4user': '',
     '_socks5pwd': '',
 }
+
+log_listener = logListenerSetup(loggingQueue=None, opts=sfConfig_API)
+log = logWorkerSetup(loggingQueue=None)
 
 class ScanRequest(BaseModel):
     target: str

--- a/sfapi.py
+++ b/sfapi.py
@@ -197,10 +197,10 @@ async def start_scan(scan_request: ScanRequest, background_tasks: BackgroundTask
         return {"scan_id": scan_id}
 
     except TypeError as e:
-        logging.error(f"TypeError during start_scan: {e}")
+        log.error(f"TypeError during start_scan: {e}")
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        logging.error(f"Unexpected error during start_scan: {e}")
+        log.error(f"Unexpected error during start_scan: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.post("/stop_scan/{scan_id}")
@@ -214,10 +214,10 @@ async def stop_scan(scan_id: str):
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid scan_id format. Must be UUID.")
     except TypeError as e:
-        logging.error(f"TypeError during stop_scan: {e}")
+        log.error(f"TypeError during stop_scan: {e}")
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        logging.error(f"Unexpected error during stop_scan: {e}")
+        log.error(f"Unexpected error during stop_scan: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.get("/modules")
@@ -233,7 +233,7 @@ async def list_modules():
         modules = sf.listModules()
         return {"modules": modules}
     except Exception as e:
-        logging.error(f"Unexpected error in list_modules: {e}", exc_info=True)
+        log.error(f"Unexpected error in list_modules: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.get("/scan_results/{scan_id}")
@@ -259,7 +259,7 @@ async def get_scan_results(scan_id: str):
 
         return {"results": formatted_results}
     except Exception as e:
-        logging.error(f"Unexpected error in get_scan_results: {e}", exc_info=True)
+        log.error(f"Unexpected error in get_scan_results: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.get("/active_scans")
@@ -275,7 +275,7 @@ async def list_active_scans():
         active_scans = dbh.scanInstanceList()
         return {"active_scans": active_scans}
     except Exception as e:
-        print(f"Unexpected error: {e}")
+        log.error(f"Unexpected error in list_active_scans: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.get("/scan_status/{scan_id}")
@@ -294,10 +294,10 @@ async def get_scan_status(scan_id: str):
         status = sf.getScanStatus(scan_id)
         return {"status": status}
     except TypeError as e:
-        print(f"TypeError: {e}")
+        log.error(f"TypeError: {e}")
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        print(f"Unexpected error: {e}")
+        log.error(f"Unexpected error: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.get("/scan_history")
@@ -313,7 +313,7 @@ async def list_scan_history():
         history = sf.listScanHistory()
         return {"history": history}
     except Exception as e:
-        print(f"Unexpected error: {e}")
+        log.error(f"Unexpected error: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.get("/export_scan_results/{scan_id}")
@@ -333,10 +333,10 @@ async def export_scan_results(scan_id: str, export_format: str):
         exported_results = sf.exportScanResults(scan_id, export_format)
         return {"exported_results": exported_results}
     except TypeError as e:
-        print(f"TypeError: {e}")
+        log.error(f"TypeError: {e}")
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        print(f"Unexpected error: {e}")
+        log.error(f"Unexpected error: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.post("/import_api_key")
@@ -355,10 +355,10 @@ async def import_api_key(api_key_request: APIKeyRequest):
         sf.importApiKey(api_key_request.module, api_key_request.key)
         return {"message": "API key imported successfully"}
     except TypeError as e:
-        print(f"TypeError: {e}")
+        log.error(f"TypeError: {e}")
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        print(f"Unexpected error: {e}")
+        log.error(f"Unexpected error: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.get("/export_api_keys")
@@ -374,7 +374,7 @@ async def export_api_keys():
         api_keys = sf.exportApiKeys()
         return {"api_keys": api_keys}
     except Exception as e:
-        print(f"Unexpected error: {e}")
+        log.error(f"Unexpected error: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.get("/scan_correlations/{scan_id}")
@@ -393,10 +393,10 @@ async def get_scan_correlations(scan_id: str):
         correlations = sf.getScanCorrelations(scan_id)
         return {"correlations": correlations}
     except TypeError as e:
-        print(f"TypeError: {e}")
+        log.error(f"TypeError: {e}")
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        print(f"Unexpected error: {e}")
+        log.error(f"Unexpected error: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.get("/scan_logs/{scan_id}")
@@ -415,10 +415,10 @@ async def get_scan_logs(scan_id: str):
         logs = sf.getScanLogs(scan_id)
         return {"logs": logs}
     except TypeError as e:
-        print(f"TypeError: {e}")
+        log.error(f"TypeError: {e}")
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        print(f"Unexpected error: {e}")
+        log.error(f"Unexpected error: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.get("/scan_summary/{scan_id}")
@@ -437,10 +437,10 @@ async def get_scan_summary(scan_id: str):
         summary = sf.getScanSummary(scan_id)
         return {"summary": summary}
     except TypeError as e:
-        print(f"TypeError: {e}")
+        log.error(f"TypeError: {e}")
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        print(f"Unexpected error: {e}")
+        log.error(f"Unexpected error: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 @app.get("/docs")


### PR DESCRIPTION
Import the SpiderFoot class from sflib.py and the SpiderFootDb class from spiderfoot/db.py in sfapi.py.

Initialize the SpiderFoot class with the configuration options and set up logging using the logListenerSetup and logWorkerSetup functions.

* Import the SpiderFoot class from sflib.py.
* Import the SpiderFootDb class from spiderfoot/db.py.
* Import the logListenerSetup and logWorkerSetup functions from spiderfoot/logger.py.
* Initialize the SpiderFoot class with the configuration options.
* Set up logging using the logListenerSetup and logWorkerSetup functions.

