### PR TITLE
Potential fix for code scanning alert no. 18: Incomplete URL substring sanitization

### DIFF
--- a/modules/sfp_abstractapi.py
+++ b/modules/sfp_abstractapi.py
@@ -289,8 +289,10 @@ class sfp_abstractapi(SpiderFootPlugin):
 
             linkedin_url = data.get("linkedin_url")
             if linkedin_url:
-                if linkedin_url.startswith("linkedin.com"):
-                    linkedin_url = f"https://{linkedin_url}"
+                parsed_url = urllib.parse.urlparse(linkedin_url)
+                if parsed_url.hostname and parsed_url.hostname.endswith("linkedin.com"):
+                    if not linkedin_url.startswith("http"):
+                        linkedin_url = f"https://{linkedin_url}"
                 e = SpiderFootEvent(
                     "SOCIAL_MEDIA",
                     f"LinkedIn (Company): <SFURL>{linkedin_url}</SFURL>",

--- a/modules/sfp_azureblobstorage.py
+++ b/modules/sfp_azureblobstorage.py
@@ -150,7 +150,9 @@ class sfp_azureblobstorage(SpiderFootPlugin):
         self.debug(f"Received event, {eventName}, from {srcModuleName}")
 
         if eventName == "LINKED_URL_EXTERNAL":
-            if ".blob.core.windows.net" in eventData:
+            from urllib.parse import urlparse
+            parsed_url = urlparse(eventData)
+            if parsed_url.hostname and parsed_url.hostname.endswith(".blob.core.windows.net"):
                 b = self.sf.urlFQDN(eventData)
                 evt = SpiderFootEvent(
                     "CLOUD_STORAGE_BUCKET", b, self.__name__, event)

--- a/modules/sfp_digitaloceanspace.py
+++ b/modules/sfp_digitaloceanspace.py
@@ -168,7 +168,10 @@ class sfp_digitaloceanspace(SpiderFootPlugin):
         self.debug(f"Received event, {eventName}, from {srcModuleName}")
 
         if eventName == "LINKED_URL_EXTERNAL":
-            if ".digitaloceanspaces.com" in eventData:
+            from urllib.parse import urlparse
+            parsed_url = urlparse(eventData)
+            host = parsed_url.hostname
+            if host and host.endswith(".digitaloceanspaces.com"):
                 b = self.sf.urlFQDN(eventData)
                 evt = SpiderFootEvent(
                     "CLOUD_STORAGE_BUCKET", b, self.__name__, event)

--- a/modules/sfp_googleobjectstorage.py
+++ b/modules/sfp_googleobjectstorage.py
@@ -15,6 +15,7 @@ import random
 import threading
 import time
 
+from urllib.parse import urlparse
 from spiderfoot import SpiderFootEvent, SpiderFootPlugin
 
 
@@ -167,7 +168,8 @@ class sfp_googleobjectstorage(SpiderFootPlugin):
         self.debug(f"Received event, {eventName}, from {srcModuleName}")
 
         if eventName == "LINKED_URL_EXTERNAL":
-            if ".storage.googleapis.com" in eventData:
+            parsed_url = urlparse(eventData)
+            if parsed_url.hostname and parsed_url.hostname.endswith(".storage.googleapis.com"):
                 b = self.sf.urlFQDN(eventData)
                 evt = SpiderFootEvent(
                     "CLOUD_STORAGE_BUCKET", b, self.__name__, event)

--- a/modules/sfp_s3bucket.py
+++ b/modules/sfp_s3bucket.py
@@ -15,6 +15,7 @@ import random
 import threading
 import time
 
+from urllib.parse import urlparse
 from spiderfoot import SpiderFootEvent, SpiderFootPlugin
 
 
@@ -164,7 +165,8 @@ class sfp_s3bucket(SpiderFootPlugin):
         self.debug(f"Received event, {eventName}, from {srcModuleName}")
 
         if eventName == "LINKED_URL_EXTERNAL":
-            if ".amazonaws.com" in eventData:
+            parsed_url = urlparse(eventData)
+            if parsed_url.hostname and parsed_url.hostname.endswith(".amazonaws.com"):
                 b = self.sf.urlFQDN(eventData)
                 if b in self.opts["endpoints"]:
                     try:


### PR DESCRIPTION
Potential fix for [https://github.com/poppopjmp/spiderfoot/security/code-scanning/18](https://github.com/poppopjmp/spiderfoot/security/code-scanning/18)

To fix the problem, we need to parse the URL and check the hostname to ensure it belongs to "linkedin.com". This can be done using the `urlparse` function from the `urllib.parse` module. We will extract the hostname and verify that it ends with "linkedin.com".

- Parse the URL using `urlparse`.
- Extract the hostname from the parsed URL.
- Check if the hostname ends with "linkedin.com".


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
