### PR TITLE
CMSeeK fix “Result” folder and send full json

### DIFF
--- a/modules/sfp_tool_cmseek.py
+++ b/modules/sfp_tool_cmseek.py
@@ -139,9 +139,23 @@ class sfp_tool_cmseek(SpiderFootPlugin):
             self.debug(f"Could not detect the CMS for {eventData}")
             return
 
-        log_path = f"{resultpath}/{eventData}/cms.json"
-        if not os.path.isfile(log_path):
-            self.error(f"File does not exist: {log_path}")
+        result_roots = [
+            resultpath,
+            os.path.join(os.path.expanduser('~'), 'Result')
+        ]
+
+        log_path = None
+        for root in result_roots:
+            candidate = os.path.join(root, eventData, 'cms.json')
+            if os.path.isfile(candidate):
+                log_path = candidate
+                break
+
+        if not log_path:
+            self.error(
+                f"CMSeeK report not found for {eventData} in "
+                f"{', '.join(result_roots)}"
+            )
             return
 
         try:
@@ -152,14 +166,8 @@ class sfp_tool_cmseek(SpiderFootPlugin):
                 f"Could not parse CMSeeK output file {log_path} as JSON: {e}")
             return
 
-        cms_name = j.get('cms_name')
-
-        if not cms_name:
-            return
-
-        cms_version = j.get('cms_version')
-
-        software = ' '.join(filter(None, [cms_name, cms_version]))
+        software = json.dumps(j, ensure_ascii=False)
+        self.debug(f"software: {software}")
 
         if not software:
             return


### PR DESCRIPTION
Hi,

First of all, thank you for taking over this project, as I think it has a lot of potential.

I wrote a fix at the time because the CMSeeK plugin wasn't returning all the info.  For example, we were missing the Wordpress version, its plugins and its users. I'd started to select the fields, but I think it's better to return the whole json to get all the info, whatever the CMS.

I've also fix a problem with the scan result path, which seems to have changed since the fork. By default, CMSeeK seems to save its scan in the current folder, and there's no option to configure this. It seems that your fork uses the spiderfoot home, so I've added a condition to the code.