### PR TITLE
fix(auth): add missing os import in SSO SAML/OIDC handlers

### DIFF
--- a/modules/sfp_4chan.py
+++ b/modules/sfp_4chan.py
@@ -6,6 +6,10 @@ from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
 import requests
 import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_4chan(SpiderFootAsyncPlugin):
     """

--- a/modules/sfp__ai_threat_intel.py
+++ b/modules/sfp__ai_threat_intel.py
@@ -34,6 +34,10 @@ import logging
 from datetime import datetime, timedelta
 import re
 import statistics
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 # Lightweight numpy-like functions for basic operations
 def mean(values: list) -> float:

--- a/modules/sfp__security_hardening.py
+++ b/modules/sfp__security_hardening.py
@@ -37,6 +37,10 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 import logging
 import ipaddress
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 try:
     from cryptography.fernet import Fernet

--- a/modules/sfp__stor_db.py
+++ b/modules/sfp__stor_db.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 # -------------------------------------------------------------------------------
 
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot, SpiderFootEvent
 
 try:
     import psycopg2

--- a/modules/sfp__stor_db_advanced.py
+++ b/modules/sfp__stor_db_advanced.py
@@ -31,6 +31,10 @@ from dataclasses import dataclass
 import hashlib
 import logging
 from contextlib import contextmanager, suppress
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot, SpiderFootEvent
 
 _log = logging.getLogger(__name__)
 

--- a/modules/sfp__stor_elasticsearch.py
+++ b/modules/sfp__stor_elasticsearch.py
@@ -18,6 +18,10 @@ from elasticsearch import Elasticsearch
 import threading
 import time
 from spiderfoot.plugins.modern_plugin import SpiderFootModernPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot, SpiderFootEvent
 
 
 class sfp__stor_elasticsearch(SpiderFootModernPlugin):

--- a/modules/sfp__stor_stdout.py
+++ b/modules/sfp__stor_stdout.py
@@ -17,6 +17,10 @@ from __future__ import annotations
 import json
 
 from spiderfoot.plugins.modern_plugin import SpiderFootModernPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot, SpiderFootEvent
 
 
 class sfp__stor_stdout(SpiderFootModernPlugin):

--- a/modules/sfp_abstractapi.py
+++ b/modules/sfp_abstractapi.py
@@ -20,6 +20,10 @@ import urllib
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_abstractapi(SpiderFootAsyncPlugin):

--- a/modules/sfp_abusech.py
+++ b/modules/sfp_abusech.py
@@ -20,6 +20,10 @@ from netaddr import IPAddress, IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_abusech(SpiderFootAsyncPlugin):

--- a/modules/sfp_abuseipdb.py
+++ b/modules/sfp_abuseipdb.py
@@ -21,6 +21,10 @@ import requests
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_abuseipdb(SpiderFootAsyncPlugin):

--- a/modules/sfp_accounts.py
+++ b/modules/sfp_accounts.py
@@ -24,6 +24,10 @@ from queue import Queue
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_accounts(SpiderFootAsyncPlugin):

--- a/modules/sfp_adblock.py
+++ b/modules/sfp_adblock.py
@@ -19,6 +19,10 @@ import adblockparser
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_adblock(SpiderFootAsyncPlugin):

--- a/modules/sfp_adguard_dns.py
+++ b/modules/sfp_adguard_dns.py
@@ -19,6 +19,10 @@ import dns.resolver
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_adguard_dns(SpiderFootAsyncPlugin):

--- a/modules/sfp_advanced_correlation.py
+++ b/modules/sfp_advanced_correlation.py
@@ -35,6 +35,11 @@ import logging
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
+    from typing import Dict
 
 
 class AdvancedCorrelationEngine:

--- a/modules/sfp_ahmia.py
+++ b/modules/sfp_ahmia.py
@@ -20,6 +20,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_ahmia(SpiderFootAsyncPlugin):

--- a/modules/sfp_alienvault.py
+++ b/modules/sfp_alienvault.py
@@ -23,6 +23,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_alienvault(SpiderFootAsyncPlugin):

--- a/modules/sfp_alienvaultiprep.py
+++ b/modules/sfp_alienvaultiprep.py
@@ -19,6 +19,10 @@ from netaddr import IPAddress, IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_alienvaultiprep(SpiderFootAsyncPlugin):

--- a/modules/sfp_aparat.py
+++ b/modules/sfp_aparat.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_aparat(SpiderFootAsyncPlugin):
     """Monitors Aparat for new videos and emits events."""

--- a/modules/sfp_apileak.py
+++ b/modules/sfp_apileak.py
@@ -7,6 +7,10 @@ from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
 import requests
 import re
 import base64
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_apileak(SpiderFootAsyncPlugin):
     """Searches for leaked API keys and secrets on GitHub and paste sites."""

--- a/modules/sfp_apple_itunes.py
+++ b/modules/sfp_apple_itunes.py
@@ -20,6 +20,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_apple_itunes(SpiderFootAsyncPlugin):

--- a/modules/sfp_arbitrum.py
+++ b/modules/sfp_arbitrum.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_arbitrum(SpiderFootAsyncPlugin):
     """Monitors Arbitrum blockchain for transactions and emits events."""

--- a/modules/sfp_archiveorg.py
+++ b/modules/sfp_archiveorg.py
@@ -20,6 +20,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_archiveorg(SpiderFootAsyncPlugin):

--- a/modules/sfp_arin.py
+++ b/modules/sfp_arin.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_arin(SpiderFootAsyncPlugin):

--- a/modules/sfp_azureblobstorage.py
+++ b/modules/sfp_azureblobstorage.py
@@ -21,6 +21,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_azureblobstorage(SpiderFootAsyncPlugin):

--- a/modules/sfp_bambenek.py
+++ b/modules/sfp_bambenek.py
@@ -17,6 +17,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_bambenek(SpiderFootAsyncPlugin):

--- a/modules/sfp_base64.py
+++ b/modules/sfp_base64.py
@@ -19,6 +19,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_base64(SpiderFootAsyncPlugin):

--- a/modules/sfp_bgpview.py
+++ b/modules/sfp_bgpview.py
@@ -19,6 +19,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_bgpview(SpiderFootAsyncPlugin):

--- a/modules/sfp_binaryedge.py
+++ b/modules/sfp_binaryedge.py
@@ -21,6 +21,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_binaryedge(SpiderFootAsyncPlugin):

--- a/modules/sfp_bingsearch.py
+++ b/modules/sfp_bingsearch.py
@@ -15,6 +15,10 @@ from __future__ import annotations
 # -------------------------------------------------------------------------------
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_bingsearch(SpiderFootAsyncPlugin):

--- a/modules/sfp_bingsharedip.py
+++ b/modules/sfp_bingsharedip.py
@@ -18,6 +18,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_bingsharedip(SpiderFootAsyncPlugin):

--- a/modules/sfp_binstring.py
+++ b/modules/sfp_binstring.py
@@ -18,6 +18,10 @@ import string
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_binstring(SpiderFootAsyncPlugin):

--- a/modules/sfp_bitcoin.py
+++ b/modules/sfp_bitcoin.py
@@ -21,6 +21,10 @@ from hashlib import sha256
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_bitcoin(SpiderFootAsyncPlugin):

--- a/modules/sfp_bitcoinwhoswho.py
+++ b/modules/sfp_bitcoinwhoswho.py
@@ -19,6 +19,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_bitcoinwhoswho(SpiderFootAsyncPlugin):

--- a/modules/sfp_blockchain.py
+++ b/modules/sfp_blockchain.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_blockchain(SpiderFootAsyncPlugin):

--- a/modules/sfp_blockchain_analytics.py
+++ b/modules/sfp_blockchain_analytics.py
@@ -35,6 +35,10 @@ from collections import defaultdict
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class BlockchainAnalyzer:

--- a/modules/sfp_blocklistde.py
+++ b/modules/sfp_blocklistde.py
@@ -18,6 +18,10 @@ from netaddr import IPAddress, IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_blocklistde(SpiderFootAsyncPlugin):

--- a/modules/sfp_bluesky.py
+++ b/modules/sfp_bluesky.py
@@ -6,6 +6,10 @@ from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
 import json
 import requests
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_bluesky(SpiderFootAsyncPlugin):
     """SpiderFoot plugin to monitor Bluesky for posts and emit events."""

--- a/modules/sfp_bnb.py
+++ b/modules/sfp_bnb.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_bnb(SpiderFootAsyncPlugin):
     """SpiderFoot plugin to monitor Binance Smart Chain (BNB) for transactions and emit events."""

--- a/modules/sfp_botscout.py
+++ b/modules/sfp_botscout.py
@@ -19,6 +19,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_botscout(SpiderFootAsyncPlugin):

--- a/modules/sfp_botvrij.py
+++ b/modules/sfp_botvrij.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_botvrij(SpiderFootAsyncPlugin):

--- a/modules/sfp_builtwith.py
+++ b/modules/sfp_builtwith.py
@@ -18,6 +18,10 @@ import time
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_builtwith(SpiderFootAsyncPlugin):

--- a/modules/sfp_c99.py
+++ b/modules/sfp_c99.py
@@ -19,6 +19,10 @@ import requests
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_c99(SpiderFootAsyncPlugin):

--- a/modules/sfp_callername.py
+++ b/modules/sfp_callername.py
@@ -19,6 +19,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_callername(SpiderFootAsyncPlugin):

--- a/modules/sfp_censys.py
+++ b/modules/sfp_censys.py
@@ -23,6 +23,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_censys(SpiderFootAsyncPlugin):

--- a/modules/sfp_certspotter.py
+++ b/modules/sfp_certspotter.py
@@ -21,6 +21,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_certspotter(SpiderFootAsyncPlugin):

--- a/modules/sfp_cinsscore.py
+++ b/modules/sfp_cinsscore.py
@@ -18,6 +18,10 @@ from netaddr import IPAddress, IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_cinsscore(SpiderFootAsyncPlugin):

--- a/modules/sfp_circllu.py
+++ b/modules/sfp_circllu.py
@@ -21,6 +21,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_circllu(SpiderFootAsyncPlugin):

--- a/modules/sfp_cisco_umbrella.py
+++ b/modules/sfp_cisco_umbrella.py
@@ -19,6 +19,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_cisco_umbrella(SpiderFootAsyncPlugin):

--- a/modules/sfp_citadel.py
+++ b/modules/sfp_citadel.py
@@ -20,6 +20,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_citadel(SpiderFootAsyncPlugin):

--- a/modules/sfp_cleanbrowsing.py
+++ b/modules/sfp_cleanbrowsing.py
@@ -20,6 +20,10 @@ import dns.resolver
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_cleanbrowsing(SpiderFootAsyncPlugin):

--- a/modules/sfp_cleantalk.py
+++ b/modules/sfp_cleantalk.py
@@ -18,6 +18,10 @@ from netaddr import IPAddress, IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_cleantalk(SpiderFootAsyncPlugin):

--- a/modules/sfp_cloudflaredns.py
+++ b/modules/sfp_cloudflaredns.py
@@ -20,6 +20,10 @@ import socket
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_cloudflaredns(SpiderFootAsyncPlugin):

--- a/modules/sfp_cloudfront.py
+++ b/modules/sfp_cloudfront.py
@@ -18,6 +18,10 @@ import dns.resolver
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_cloudfront(SpiderFootAsyncPlugin):

--- a/modules/sfp_coinblocker.py
+++ b/modules/sfp_coinblocker.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_coinblocker(SpiderFootAsyncPlugin):

--- a/modules/sfp_commoncrawl.py
+++ b/modules/sfp_commoncrawl.py
@@ -20,6 +20,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_commoncrawl(SpiderFootAsyncPlugin):

--- a/modules/sfp_comodo.py
+++ b/modules/sfp_comodo.py
@@ -19,6 +19,10 @@ import dns.resolver
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_comodo(SpiderFootAsyncPlugin):

--- a/modules/sfp_company.py
+++ b/modules/sfp_company.py
@@ -19,6 +19,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_company(SpiderFootAsyncPlugin):

--- a/modules/sfp_cookie.py
+++ b/modules/sfp_cookie.py
@@ -18,6 +18,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_cookie(SpiderFootAsyncPlugin):

--- a/modules/sfp_countryname.py
+++ b/modules/sfp_countryname.py
@@ -22,6 +22,10 @@ from phonenumbers.phonenumberutil import region_code_for_country_code
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_countryname(SpiderFootAsyncPlugin):

--- a/modules/sfp_creditcard.py
+++ b/modules/sfp_creditcard.py
@@ -17,6 +17,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_creditcard(SpiderFootAsyncPlugin):

--- a/modules/sfp_criminalip.py
+++ b/modules/sfp_criminalip.py
@@ -20,6 +20,10 @@ import urllib
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_criminalip(SpiderFootAsyncPlugin):

--- a/modules/sfp_crossref.py
+++ b/modules/sfp_crossref.py
@@ -21,6 +21,10 @@ import re
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_crossref(SpiderFootAsyncPlugin):

--- a/modules/sfp_crt.py
+++ b/modules/sfp_crt.py
@@ -21,6 +21,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_crt(SpiderFootAsyncPlugin):

--- a/modules/sfp_customfeed.py
+++ b/modules/sfp_customfeed.py
@@ -21,6 +21,10 @@ from netaddr import IPAddress, IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 malchecks = {
     'Custom Threat Data': {

--- a/modules/sfp_cybercrimetracker.py
+++ b/modules/sfp_cybercrimetracker.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_cybercrimetracker(SpiderFootAsyncPlugin):

--- a/modules/sfp_debounce.py
+++ b/modules/sfp_debounce.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_debounce(SpiderFootAsyncPlugin):

--- a/modules/sfp_deepinfo.py
+++ b/modules/sfp_deepinfo.py
@@ -18,6 +18,10 @@ import json
 import time
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_deepinfo(SpiderFootAsyncPlugin):

--- a/modules/sfp_dehashed.py
+++ b/modules/sfp_dehashed.py
@@ -19,6 +19,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_dehashed(SpiderFootAsyncPlugin):

--- a/modules/sfp_dideo.py
+++ b/modules/sfp_dideo.py
@@ -7,6 +7,10 @@ from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
 import re
 import json
 import urllib.parse
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_dideo(SpiderFootAsyncPlugin):

--- a/modules/sfp_digitaloceanspace.py
+++ b/modules/sfp_digitaloceanspace.py
@@ -21,6 +21,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_digitaloceanspace(SpiderFootAsyncPlugin):

--- a/modules/sfp_discord.py
+++ b/modules/sfp_discord.py
@@ -6,6 +6,10 @@ from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
 import json
 import requests
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_discord(SpiderFootAsyncPlugin):
     """Discord Channel Monitor"""

--- a/modules/sfp_dns_for_family.py
+++ b/modules/sfp_dns_for_family.py
@@ -18,6 +18,10 @@ import dns.resolver
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_dns_for_family(SpiderFootAsyncPlugin):

--- a/modules/sfp_dnsbrute.py
+++ b/modules/sfp_dnsbrute.py
@@ -22,6 +22,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_dnsbrute(SpiderFootAsyncPlugin):

--- a/modules/sfp_dnscommonsrv.py
+++ b/modules/sfp_dnscommonsrv.py
@@ -19,6 +19,10 @@ import dns.resolver
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_dnscommonsrv(SpiderFootAsyncPlugin):

--- a/modules/sfp_dnsdumpster.py
+++ b/modules/sfp_dnsdumpster.py
@@ -21,6 +21,10 @@ from bs4 import BeautifulSoup
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_dnsdumpster(SpiderFootAsyncPlugin):

--- a/modules/sfp_dnsneighbor.py
+++ b/modules/sfp_dnsneighbor.py
@@ -19,6 +19,10 @@ import ipaddress
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_dnsneighbor(SpiderFootAsyncPlugin):

--- a/modules/sfp_dnsraw.py
+++ b/modules/sfp_dnsraw.py
@@ -23,6 +23,10 @@ import dns.resolver
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_dnsraw(SpiderFootAsyncPlugin):

--- a/modules/sfp_dnsresolve.py
+++ b/modules/sfp_dnsresolve.py
@@ -22,6 +22,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot, SpiderFootTarget
 
 
 class sfp_dnsresolve(SpiderFootAsyncPlugin):

--- a/modules/sfp_dnszonexfer.py
+++ b/modules/sfp_dnszonexfer.py
@@ -21,6 +21,10 @@ import dns.zone
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_dnszonexfer(SpiderFootAsyncPlugin):

--- a/modules/sfp_douyin.py
+++ b/modules/sfp_douyin.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_douyin(SpiderFootAsyncPlugin):
     """Douyin plugin for monitoring video uploads."""

--- a/modules/sfp_dronebl.py
+++ b/modules/sfp_dronebl.py
@@ -20,6 +20,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_dronebl(SpiderFootAsyncPlugin):

--- a/modules/sfp_duckduckgo.py
+++ b/modules/sfp_duckduckgo.py
@@ -18,6 +18,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_duckduckgo(SpiderFootAsyncPlugin):

--- a/modules/sfp_email.py
+++ b/modules/sfp_email.py
@@ -17,6 +17,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_email(SpiderFootAsyncPlugin):

--- a/modules/sfp_emailcrawlr.py
+++ b/modules/sfp_emailcrawlr.py
@@ -21,6 +21,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_emailcrawlr(SpiderFootAsyncPlugin):

--- a/modules/sfp_emailformat.py
+++ b/modules/sfp_emailformat.py
@@ -21,6 +21,10 @@ from bs4 import BeautifulSoup
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_emailformat(SpiderFootAsyncPlugin):

--- a/modules/sfp_emailrep.py
+++ b/modules/sfp_emailrep.py
@@ -19,6 +19,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_emailrep(SpiderFootAsyncPlugin):

--- a/modules/sfp_emergingthreats.py
+++ b/modules/sfp_emergingthreats.py
@@ -19,6 +19,10 @@ from netaddr import IPAddress, IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_emergingthreats(SpiderFootAsyncPlugin):

--- a/modules/sfp_errors.py
+++ b/modules/sfp_errors.py
@@ -18,6 +18,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 # Taken from Google Dorks on exploit-db.com
 regexps = dict({

--- a/modules/sfp_ethereum.py
+++ b/modules/sfp_ethereum.py
@@ -19,6 +19,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_ethereum(SpiderFootAsyncPlugin):

--- a/modules/sfp_etherscan.py
+++ b/modules/sfp_etherscan.py
@@ -20,6 +20,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_etherscan(SpiderFootAsyncPlugin):

--- a/modules/sfp_example.py
+++ b/modules/sfp_example.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 """SpiderFoot plug-in module: example."""
 
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot, SpiderFootTarget
 
 class sfp_example(SpiderFootAsyncPlugin):
     """Example SpiderFoot plugin."""

--- a/modules/sfp_filemeta.py
+++ b/modules/sfp_filemeta.py
@@ -28,6 +28,10 @@ import pptx
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_filemeta(SpiderFootAsyncPlugin):

--- a/modules/sfp_flickr.py
+++ b/modules/sfp_flickr.py
@@ -22,6 +22,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_flickr(SpiderFootAsyncPlugin):

--- a/modules/sfp_focsec.py
+++ b/modules/sfp_focsec.py
@@ -19,6 +19,10 @@ import urllib
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_focsec(SpiderFootAsyncPlugin):

--- a/modules/sfp_fofa.py
+++ b/modules/sfp_fofa.py
@@ -21,6 +21,10 @@ import base64
 from typing import Any
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_fofa(SpiderFootAsyncPlugin):

--- a/modules/sfp_fortinet.py
+++ b/modules/sfp_fortinet.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_fortinet(SpiderFootAsyncPlugin):

--- a/modules/sfp_fraudguard.py
+++ b/modules/sfp_fraudguard.py
@@ -23,6 +23,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_fraudguard(SpiderFootAsyncPlugin):

--- a/modules/sfp_fullcontact.py
+++ b/modules/sfp_fullcontact.py
@@ -19,6 +19,10 @@ from datetime import datetime
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_fullcontact(SpiderFootAsyncPlugin):

--- a/modules/sfp_fullhunt.py
+++ b/modules/sfp_fullhunt.py
@@ -18,6 +18,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_fullhunt(SpiderFootAsyncPlugin):

--- a/modules/sfp_github.py
+++ b/modules/sfp_github.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_github(SpiderFootAsyncPlugin):

--- a/modules/sfp_gleif.py
+++ b/modules/sfp_gleif.py
@@ -20,6 +20,10 @@ import urllib
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_gleif(SpiderFootAsyncPlugin):

--- a/modules/sfp_google_tag_manager.py
+++ b/modules/sfp_google_tag_manager.py
@@ -19,6 +19,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_google_tag_manager(SpiderFootAsyncPlugin):

--- a/modules/sfp_googlemaps.py
+++ b/modules/sfp_googlemaps.py
@@ -20,6 +20,10 @@ import urllib
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_googlemaps(SpiderFootAsyncPlugin):

--- a/modules/sfp_googleobjectstorage.py
+++ b/modules/sfp_googleobjectstorage.py
@@ -22,6 +22,10 @@ import time
 from urllib.parse import urlparse
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_googleobjectstorage(SpiderFootAsyncPlugin):

--- a/modules/sfp_googlesafebrowsing.py
+++ b/modules/sfp_googlesafebrowsing.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_googlesafebrowsing(SpiderFootAsyncPlugin):

--- a/modules/sfp_googlesearch.py
+++ b/modules/sfp_googlesearch.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_googlesearch(SpiderFootAsyncPlugin):

--- a/modules/sfp_gravatar.py
+++ b/modules/sfp_gravatar.py
@@ -21,6 +21,10 @@ import time
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_gravatar(SpiderFootAsyncPlugin):

--- a/modules/sfp_grayhatwarfare.py
+++ b/modules/sfp_grayhatwarfare.py
@@ -19,6 +19,10 @@ import urllib
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_grayhatwarfare(SpiderFootAsyncPlugin):

--- a/modules/sfp_greensnow.py
+++ b/modules/sfp_greensnow.py
@@ -18,6 +18,10 @@ from netaddr import IPAddress, IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_greensnow(SpiderFootAsyncPlugin):

--- a/modules/sfp_grep_app.py
+++ b/modules/sfp_grep_app.py
@@ -22,6 +22,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_grep_app(SpiderFootAsyncPlugin):

--- a/modules/sfp_greynoise.py
+++ b/modules/sfp_greynoise.py
@@ -23,6 +23,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_greynoise(SpiderFootAsyncPlugin):

--- a/modules/sfp_greynoise_community.py
+++ b/modules/sfp_greynoise_community.py
@@ -22,6 +22,10 @@ from datetime import datetime
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_greynoise_community(SpiderFootAsyncPlugin):

--- a/modules/sfp_h1nobbdde.py
+++ b/modules/sfp_h1nobbdde.py
@@ -17,6 +17,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_h1nobbdde(SpiderFootAsyncPlugin):

--- a/modules/sfp_hackertarget.py
+++ b/modules/sfp_hackertarget.py
@@ -24,6 +24,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_hackertarget(SpiderFootAsyncPlugin):

--- a/modules/sfp_hashes.py
+++ b/modules/sfp_hashes.py
@@ -17,6 +17,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_hashes(SpiderFootAsyncPlugin):

--- a/modules/sfp_haveibeenpwned.py
+++ b/modules/sfp_haveibeenpwned.py
@@ -19,6 +19,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_haveibeenpwned(SpiderFootAsyncPlugin):

--- a/modules/sfp_honeypot.py
+++ b/modules/sfp_honeypot.py
@@ -19,6 +19,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_honeypot(SpiderFootAsyncPlugin):

--- a/modules/sfp_hosting.py
+++ b/modules/sfp_hosting.py
@@ -19,6 +19,10 @@ from netaddr import IPAddress
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_hosting(SpiderFootAsyncPlugin):

--- a/modules/sfp_hostio.py
+++ b/modules/sfp_hostio.py
@@ -17,6 +17,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_hostio(SpiderFootAsyncPlugin):

--- a/modules/sfp_hunter.py
+++ b/modules/sfp_hunter.py
@@ -18,6 +18,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_hunter(SpiderFootAsyncPlugin):

--- a/modules/sfp_hybrid_analysis.py
+++ b/modules/sfp_hybrid_analysis.py
@@ -19,6 +19,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_hybrid_analysis(SpiderFootAsyncPlugin):

--- a/modules/sfp_iban.py
+++ b/modules/sfp_iban.py
@@ -17,6 +17,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_iban(SpiderFootAsyncPlugin):

--- a/modules/sfp_iknowwhatyoudownload.py
+++ b/modules/sfp_iknowwhatyoudownload.py
@@ -18,6 +18,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_iknowwhatyoudownload(SpiderFootAsyncPlugin):

--- a/modules/sfp_instagram.py
+++ b/modules/sfp_instagram.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_instagram(SpiderFootAsyncPlugin):
     """Monitors Instagram for new posts or stories and emits events."""

--- a/modules/sfp_intelx.py
+++ b/modules/sfp_intelx.py
@@ -21,6 +21,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_intelx(SpiderFootAsyncPlugin):

--- a/modules/sfp_intfiles.py
+++ b/modules/sfp_intfiles.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_intfiles(SpiderFootAsyncPlugin):

--- a/modules/sfp_ipapico.py
+++ b/modules/sfp_ipapico.py
@@ -20,6 +20,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_ipapico(SpiderFootAsyncPlugin):

--- a/modules/sfp_ipapico_modern.py
+++ b/modules/sfp_ipapico_modern.py
@@ -38,6 +38,10 @@ from typing import Any
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_ipapico_modern(SpiderFootAsyncPlugin):

--- a/modules/sfp_ipapicom.py
+++ b/modules/sfp_ipapicom.py
@@ -20,6 +20,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_ipapicom(SpiderFootAsyncPlugin):

--- a/modules/sfp_ipinfo.py
+++ b/modules/sfp_ipinfo.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_ipinfo(SpiderFootAsyncPlugin):

--- a/modules/sfp_ipinfo_modern.py
+++ b/modules/sfp_ipinfo_modern.py
@@ -36,6 +36,10 @@ from typing import Any
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_ipinfo_modern(SpiderFootAsyncPlugin):

--- a/modules/sfp_ipqualityscore.py
+++ b/modules/sfp_ipqualityscore.py
@@ -18,6 +18,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_ipqualityscore(SpiderFootAsyncPlugin):

--- a/modules/sfp_ipregistry.py
+++ b/modules/sfp_ipregistry.py
@@ -19,6 +19,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_ipregistry(SpiderFootAsyncPlugin):

--- a/modules/sfp_ipstack.py
+++ b/modules/sfp_ipstack.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_ipstack(SpiderFootAsyncPlugin):

--- a/modules/sfp_isc.py
+++ b/modules/sfp_isc.py
@@ -18,6 +18,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_isc(SpiderFootAsyncPlugin):

--- a/modules/sfp_jsonwhoiscom.py
+++ b/modules/sfp_jsonwhoiscom.py
@@ -20,6 +20,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_jsonwhoiscom(SpiderFootAsyncPlugin):

--- a/modules/sfp_junkfiles.py
+++ b/modules/sfp_junkfiles.py
@@ -18,6 +18,10 @@ import random
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_junkfiles(SpiderFootAsyncPlugin):

--- a/modules/sfp_keybase.py
+++ b/modules/sfp_keybase.py
@@ -22,6 +22,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_keybase(SpiderFootAsyncPlugin):

--- a/modules/sfp_koodous.py
+++ b/modules/sfp_koodous.py
@@ -21,6 +21,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_koodous(SpiderFootAsyncPlugin):

--- a/modules/sfp_leakcheck.py
+++ b/modules/sfp_leakcheck.py
@@ -19,6 +19,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_leakcheck(SpiderFootAsyncPlugin):

--- a/modules/sfp_leakix.py
+++ b/modules/sfp_leakix.py
@@ -19,6 +19,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_leakix(SpiderFootAsyncPlugin):

--- a/modules/sfp_luminar.py
+++ b/modules/sfp_luminar.py
@@ -20,6 +20,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_luminar(SpiderFootAsyncPlugin):

--- a/modules/sfp_maltiverse.py
+++ b/modules/sfp_maltiverse.py
@@ -22,6 +22,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_maltiverse(SpiderFootAsyncPlugin):

--- a/modules/sfp_malwarepatrol.py
+++ b/modules/sfp_malwarepatrol.py
@@ -17,6 +17,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_malwarepatrol(SpiderFootAsyncPlugin):

--- a/modules/sfp_mandiant_ti.py
+++ b/modules/sfp_mandiant_ti.py
@@ -20,6 +20,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_mandiant_ti(SpiderFootAsyncPlugin):

--- a/modules/sfp_mastodon.py
+++ b/modules/sfp_mastodon.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_mastodon(SpiderFootAsyncPlugin):
     """Monitors Mastodon for posts and emits events."""

--- a/modules/sfp_matrix.py
+++ b/modules/sfp_matrix.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_matrix(SpiderFootAsyncPlugin):
     """Monitors Matrix servers for messages and emits events."""

--- a/modules/sfp_mattermost.py
+++ b/modules/sfp_mattermost.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_mattermost(SpiderFootAsyncPlugin):
     """Monitors Mattermost servers for messages and emits events."""

--- a/modules/sfp_metadefender.py
+++ b/modules/sfp_metadefender.py
@@ -19,6 +19,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_metadefender(SpiderFootAsyncPlugin):

--- a/modules/sfp_mnemonic.py
+++ b/modules/sfp_mnemonic.py
@@ -21,6 +21,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_mnemonic(SpiderFootAsyncPlugin):

--- a/modules/sfp_multiproxy.py
+++ b/modules/sfp_multiproxy.py
@@ -19,6 +19,10 @@ from netaddr import IPAddress, IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_multiproxy(SpiderFootAsyncPlugin):

--- a/modules/sfp_myspace.py
+++ b/modules/sfp_myspace.py
@@ -17,6 +17,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_myspace(SpiderFootAsyncPlugin):

--- a/modules/sfp_nameapi.py
+++ b/modules/sfp_nameapi.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_nameapi(SpiderFootAsyncPlugin):

--- a/modules/sfp_names.py
+++ b/modules/sfp_names.py
@@ -18,6 +18,10 @@ import re
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_names(SpiderFootAsyncPlugin):

--- a/modules/sfp_netlas.py
+++ b/modules/sfp_netlas.py
@@ -18,6 +18,10 @@ import urllib
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_netlas(SpiderFootAsyncPlugin):

--- a/modules/sfp_networksdb.py
+++ b/modules/sfp_networksdb.py
@@ -21,6 +21,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_networksdb(SpiderFootAsyncPlugin):

--- a/modules/sfp_neutrinoapi.py
+++ b/modules/sfp_neutrinoapi.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_neutrinoapi(SpiderFootAsyncPlugin):

--- a/modules/sfp_numverify.py
+++ b/modules/sfp_numverify.py
@@ -20,6 +20,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_numverify(SpiderFootAsyncPlugin):

--- a/modules/sfp_onioncity.py
+++ b/modules/sfp_onioncity.py
@@ -19,6 +19,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_onioncity(SpiderFootAsyncPlugin):

--- a/modules/sfp_onionsearchengine.py
+++ b/modules/sfp_onionsearchengine.py
@@ -20,6 +20,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_onionsearchengine(SpiderFootAsyncPlugin):

--- a/modules/sfp_onyphe.py
+++ b/modules/sfp_onyphe.py
@@ -21,6 +21,10 @@ from datetime import datetime
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_onyphe(SpiderFootAsyncPlugin):

--- a/modules/sfp_openbugbounty.py
+++ b/modules/sfp_openbugbounty.py
@@ -17,6 +17,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_openbugbounty(SpiderFootAsyncPlugin):

--- a/modules/sfp_opencorporates.py
+++ b/modules/sfp_opencorporates.py
@@ -20,6 +20,10 @@ import urllib
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_opencorporates(SpiderFootAsyncPlugin):

--- a/modules/sfp_opendns.py
+++ b/modules/sfp_opendns.py
@@ -19,6 +19,10 @@ import dns.resolver
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_opendns(SpiderFootAsyncPlugin):

--- a/modules/sfp_opennic.py
+++ b/modules/sfp_opennic.py
@@ -19,6 +19,10 @@ import dns.resolver
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_opennic(SpiderFootAsyncPlugin):

--- a/modules/sfp_openphish.py
+++ b/modules/sfp_openphish.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_openphish(SpiderFootAsyncPlugin):

--- a/modules/sfp_openstreetmap.py
+++ b/modules/sfp_openstreetmap.py
@@ -22,6 +22,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_openstreetmap(SpiderFootAsyncPlugin):

--- a/modules/sfp_openwifimap.py
+++ b/modules/sfp_openwifimap.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_openwifimap(SpiderFootAsyncPlugin):
     """Queries OpenWifiMap.net for public WiFi hotspots and related info."""

--- a/modules/sfp_pageinfo.py
+++ b/modules/sfp_pageinfo.py
@@ -20,6 +20,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 # Indentify pages that use Javascript libs, handle passwords, have forms,
 # permit file uploads and more to come.

--- a/modules/sfp_pastebin.py
+++ b/modules/sfp_pastebin.py
@@ -19,6 +19,10 @@ import re
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_pastebin(SpiderFootAsyncPlugin):

--- a/modules/sfp_performance_optimizer.py
+++ b/modules/sfp_performance_optimizer.py
@@ -37,6 +37,10 @@ import resource
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class TTLCache:

--- a/modules/sfp_pgp.py
+++ b/modules/sfp_pgp.py
@@ -18,6 +18,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_pgp(SpiderFootAsyncPlugin):

--- a/modules/sfp_phishtank.py
+++ b/modules/sfp_phishtank.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_phishtank(SpiderFootAsyncPlugin):

--- a/modules/sfp_phone.py
+++ b/modules/sfp_phone.py
@@ -22,6 +22,10 @@ from phonenumbers import carrier
 # from phonenumbers import geocoder
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_phone(SpiderFootAsyncPlugin):

--- a/modules/sfp_portscan_tcp.py
+++ b/modules/sfp_portscan_tcp.py
@@ -23,6 +23,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_portscan_tcp(SpiderFootAsyncPlugin):

--- a/modules/sfp_projectdiscovery.py
+++ b/modules/sfp_projectdiscovery.py
@@ -18,6 +18,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_projectdiscovery(SpiderFootAsyncPlugin):

--- a/modules/sfp_pulsedive.py
+++ b/modules/sfp_pulsedive.py
@@ -23,6 +23,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_pulsedive(SpiderFootAsyncPlugin):

--- a/modules/sfp_quad9.py
+++ b/modules/sfp_quad9.py
@@ -19,6 +19,10 @@ import dns.resolver
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_quad9(SpiderFootAsyncPlugin):

--- a/modules/sfp_recordedfuture.py
+++ b/modules/sfp_recordedfuture.py
@@ -20,6 +20,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_recordedfuture(SpiderFootAsyncPlugin):

--- a/modules/sfp_reddit.py
+++ b/modules/sfp_reddit.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_reddit(SpiderFootAsyncPlugin):
     """Monitors specified subreddits for new posts and emits events."""

--- a/modules/sfp_reversewhois.py
+++ b/modules/sfp_reversewhois.py
@@ -20,6 +20,10 @@ from bs4 import BeautifulSoup
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_reversewhois(SpiderFootAsyncPlugin):

--- a/modules/sfp_ripe.py
+++ b/modules/sfp_ripe.py
@@ -20,6 +20,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_ripe(SpiderFootAsyncPlugin):

--- a/modules/sfp_rocketchat.py
+++ b/modules/sfp_rocketchat.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_rocketchat(SpiderFootAsyncPlugin):
     """Monitors Rocket.Chat servers for messages and emits events."""

--- a/modules/sfp_rocketreach.py
+++ b/modules/sfp_rocketreach.py
@@ -20,6 +20,10 @@ import time
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
 import requests
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_rocketreach(SpiderFootAsyncPlugin):

--- a/modules/sfp_rubika.py
+++ b/modules/sfp_rubika.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_rubika(SpiderFootAsyncPlugin):
     """Monitors Rubika for new messages and emits events."""

--- a/modules/sfp_s3bucket.py
+++ b/modules/sfp_s3bucket.py
@@ -22,6 +22,10 @@ import time
 from urllib.parse import urlparse
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_s3bucket(SpiderFootAsyncPlugin):

--- a/modules/sfp_searchcode.py
+++ b/modules/sfp_searchcode.py
@@ -20,6 +20,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_searchcode(SpiderFootAsyncPlugin):

--- a/modules/sfp_securitytrails.py
+++ b/modules/sfp_securitytrails.py
@@ -19,6 +19,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_securitytrails(SpiderFootAsyncPlugin):

--- a/modules/sfp_seon.py
+++ b/modules/sfp_seon.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_seon(SpiderFootAsyncPlugin):

--- a/modules/sfp_shodan.py
+++ b/modules/sfp_shodan.py
@@ -22,6 +22,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_shodan(SpiderFootAsyncPlugin):

--- a/modules/sfp_similar.py
+++ b/modules/sfp_similar.py
@@ -17,6 +17,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 nearchars = {
     'a': ['4', 's'],

--- a/modules/sfp_skymem.py
+++ b/modules/sfp_skymem.py
@@ -19,6 +19,10 @@ import re
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_skymem(SpiderFootAsyncPlugin):

--- a/modules/sfp_slideshare.py
+++ b/modules/sfp_slideshare.py
@@ -17,6 +17,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_slideshare(SpiderFootAsyncPlugin):

--- a/modules/sfp_snov.py
+++ b/modules/sfp_snov.py
@@ -20,6 +20,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_snov(SpiderFootAsyncPlugin):

--- a/modules/sfp_social.py
+++ b/modules/sfp_social.py
@@ -18,6 +18,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 regexps = dict({
     "LinkedIn (Individual)": list(['.*linkedin.com/in/([a-zA-Z0-9_]+$)']),

--- a/modules/sfp_sociallinks.py
+++ b/modules/sfp_sociallinks.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_sociallinks(SpiderFootAsyncPlugin):

--- a/modules/sfp_socialprofiles.py
+++ b/modules/sfp_socialprofiles.py
@@ -19,6 +19,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 sites = {
     # Search string to use, domain name the profile will sit on within

--- a/modules/sfp_sorbs.py
+++ b/modules/sfp_sorbs.py
@@ -20,6 +20,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_sorbs(SpiderFootAsyncPlugin):

--- a/modules/sfp_soroush.py
+++ b/modules/sfp_soroush.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_soroush(SpiderFootAsyncPlugin):
     """Monitors Soroush for new messages and emits events."""

--- a/modules/sfp_spamcop.py
+++ b/modules/sfp_spamcop.py
@@ -20,6 +20,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_spamcop(SpiderFootAsyncPlugin):

--- a/modules/sfp_spamhaus.py
+++ b/modules/sfp_spamhaus.py
@@ -20,6 +20,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_spamhaus(SpiderFootAsyncPlugin):

--- a/modules/sfp_spider.py
+++ b/modules/sfp_spider.py
@@ -20,6 +20,10 @@ import time
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_spider(SpiderFootAsyncPlugin):

--- a/modules/sfp_spur.py
+++ b/modules/sfp_spur.py
@@ -21,6 +21,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_spur(SpiderFootAsyncPlugin):

--- a/modules/sfp_sslcert.py
+++ b/modules/sfp_sslcert.py
@@ -19,6 +19,10 @@ from urllib.parse import urlparse
 from spiderfoot import SpiderFootEvent
 from spiderfoot import SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_sslcert(SpiderFootAsyncPlugin):

--- a/modules/sfp_stackoverflow.py
+++ b/modules/sfp_stackoverflow.py
@@ -20,6 +20,10 @@ import time
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_stackoverflow(SpiderFootAsyncPlugin):

--- a/modules/sfp_stevenblack_hosts.py
+++ b/modules/sfp_stevenblack_hosts.py
@@ -17,6 +17,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_stevenblack_hosts(SpiderFootAsyncPlugin):

--- a/modules/sfp_strangeheaders.py
+++ b/modules/sfp_strangeheaders.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 # Standard headers, taken from http://en.wikipedia.org/wiki/List_of_HTTP_header_fields
 headers = [

--- a/modules/sfp_subdomain_takeover.py
+++ b/modules/sfp_subdomain_takeover.py
@@ -20,6 +20,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_subdomain_takeover(SpiderFootAsyncPlugin):

--- a/modules/sfp_sublist3r.py
+++ b/modules/sfp_sublist3r.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_sublist3r(SpiderFootAsyncPlugin):

--- a/modules/sfp_surbl.py
+++ b/modules/sfp_surbl.py
@@ -19,6 +19,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_surbl(SpiderFootAsyncPlugin):

--- a/modules/sfp_talosintel.py
+++ b/modules/sfp_talosintel.py
@@ -19,6 +19,10 @@ from netaddr import IPAddress, IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_talosintel(SpiderFootAsyncPlugin):

--- a/modules/sfp_telegram.py
+++ b/modules/sfp_telegram.py
@@ -6,6 +6,10 @@ from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
 import time
 import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 try:
     from telethon import TelegramClient, events

--- a/modules/sfp_textmagic.py
+++ b/modules/sfp_textmagic.py
@@ -18,6 +18,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_textmagic(SpiderFootAsyncPlugin):

--- a/modules/sfp_threatcrowd.py
+++ b/modules/sfp_threatcrowd.py
@@ -20,6 +20,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_threatcrowd(SpiderFootAsyncPlugin):

--- a/modules/sfp_threatfox.py
+++ b/modules/sfp_threatfox.py
@@ -19,6 +19,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_threatfox(SpiderFootAsyncPlugin):

--- a/modules/sfp_threatminer.py
+++ b/modules/sfp_threatminer.py
@@ -22,6 +22,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_threatminer(SpiderFootAsyncPlugin):

--- a/modules/sfp_tiktok_osint.py
+++ b/modules/sfp_tiktok_osint.py
@@ -30,6 +30,10 @@ from typing import Any
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_tiktok_osint(SpiderFootAsyncPlugin):

--- a/modules/sfp_tldsearch.py
+++ b/modules/sfp_tldsearch.py
@@ -23,6 +23,10 @@ import dns.resolver
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_tldsearch(SpiderFootAsyncPlugin):

--- a/modules/sfp_tool_cmseek.py
+++ b/modules/sfp_tool_cmseek.py
@@ -23,6 +23,10 @@ from subprocess import PIPE, Popen, TimeoutExpired
 from spiderfoot import SpiderFootEvent
 from spiderfoot import SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_tool_cmseek(SpiderFootAsyncPlugin):

--- a/modules/sfp_tool_dnstwist.py
+++ b/modules/sfp_tool_dnstwist.py
@@ -23,6 +23,10 @@ from subprocess import PIPE, Popen, TimeoutExpired
 from spiderfoot import SpiderFootEvent
 from spiderfoot import SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_tool_dnstwist(SpiderFootAsyncPlugin):

--- a/modules/sfp_tool_gobuster.py
+++ b/modules/sfp_tool_gobuster.py
@@ -25,6 +25,10 @@ import io
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_tool_gobuster(SpiderFootAsyncPlugin):

--- a/modules/sfp_tool_nbtscan.py
+++ b/modules/sfp_tool_nbtscan.py
@@ -22,6 +22,10 @@ from subprocess import PIPE, Popen, TimeoutExpired
 from spiderfoot import SpiderFootEvent
 from spiderfoot import SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_tool_nbtscan(SpiderFootAsyncPlugin):

--- a/modules/sfp_tool_onesixtyone.py
+++ b/modules/sfp_tool_onesixtyone.py
@@ -22,6 +22,10 @@ from subprocess import PIPE, Popen, TimeoutExpired
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_tool_onesixtyone(SpiderFootAsyncPlugin):

--- a/modules/sfp_tool_phoneinfoga.py
+++ b/modules/sfp_tool_phoneinfoga.py
@@ -8,6 +8,10 @@ import json
 import time
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_tool_phoneinfoga(SpiderFootAsyncPlugin):
     """Gather phone number intelligence using PhoneInfoga."""

--- a/modules/sfp_tool_retirejs.py
+++ b/modules/sfp_tool_retirejs.py
@@ -22,6 +22,10 @@ from subprocess import Popen, PIPE, TimeoutExpired
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_tool_retirejs(SpiderFootAsyncPlugin):

--- a/modules/sfp_tool_snallygaster.py
+++ b/modules/sfp_tool_snallygaster.py
@@ -21,6 +21,10 @@ from subprocess import PIPE, Popen, TimeoutExpired
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_tool_snallygaster(SpiderFootAsyncPlugin):

--- a/modules/sfp_tool_testsslsh.py
+++ b/modules/sfp_tool_testsslsh.py
@@ -23,6 +23,10 @@ from subprocess import PIPE, Popen, TimeoutExpired
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_tool_testsslsh(SpiderFootAsyncPlugin):

--- a/modules/sfp_tool_trufflehog.py
+++ b/modules/sfp_tool_trufflehog.py
@@ -22,6 +22,10 @@ from urllib.parse import urlparse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_tool_trufflehog(SpiderFootAsyncPlugin):

--- a/modules/sfp_tool_wafw00f.py
+++ b/modules/sfp_tool_wafw00f.py
@@ -22,6 +22,10 @@ from subprocess import PIPE, Popen, TimeoutExpired
 from spiderfoot import SpiderFootEvent
 from spiderfoot import SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_tool_wafw00f(SpiderFootAsyncPlugin):

--- a/modules/sfp_tool_wappalyzer.py
+++ b/modules/sfp_tool_wappalyzer.py
@@ -18,6 +18,10 @@ import json
 import requests
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_tool_wappalyzer(SpiderFootAsyncPlugin):

--- a/modules/sfp_tool_whatweb.py
+++ b/modules/sfp_tool_whatweb.py
@@ -23,6 +23,10 @@ from subprocess import PIPE, Popen, TimeoutExpired
 from spiderfoot import SpiderFootEvent
 from spiderfoot import SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_tool_whatweb(SpiderFootAsyncPlugin):

--- a/modules/sfp_torch.py
+++ b/modules/sfp_torch.py
@@ -20,6 +20,10 @@ from urllib.parse import urlencode
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_torch(SpiderFootAsyncPlugin):

--- a/modules/sfp_torexits.py
+++ b/modules/sfp_torexits.py
@@ -21,6 +21,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_torexits(SpiderFootAsyncPlugin):

--- a/modules/sfp_tron.py
+++ b/modules/sfp_tron.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_tron(SpiderFootAsyncPlugin):
     """Monitors Tron blockchain for transactions and emits events."""

--- a/modules/sfp_trumail.py
+++ b/modules/sfp_trumail.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_trumail(SpiderFootAsyncPlugin):

--- a/modules/sfp_twilio.py
+++ b/modules/sfp_twilio.py
@@ -19,6 +19,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_twilio(SpiderFootAsyncPlugin):

--- a/modules/sfp_twitter.py
+++ b/modules/sfp_twitter.py
@@ -17,6 +17,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_twitter(SpiderFootAsyncPlugin):

--- a/modules/sfp_uceprotect.py
+++ b/modules/sfp_uceprotect.py
@@ -20,6 +20,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_uceprotect(SpiderFootAsyncPlugin):

--- a/modules/sfp_unwiredlabs.py
+++ b/modules/sfp_unwiredlabs.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_unwiredlabs(SpiderFootAsyncPlugin):
     """Queries UnwiredLabs for geolocation data based on cell towers, WiFi, or IP."""

--- a/modules/sfp_urlscan.py
+++ b/modules/sfp_urlscan.py
@@ -19,6 +19,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_urlscan(SpiderFootAsyncPlugin):

--- a/modules/sfp_venmo.py
+++ b/modules/sfp_venmo.py
@@ -18,6 +18,10 @@ import time
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_venmo(SpiderFootAsyncPlugin):

--- a/modules/sfp_viewdns.py
+++ b/modules/sfp_viewdns.py
@@ -19,6 +19,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_viewdns(SpiderFootAsyncPlugin):

--- a/modules/sfp_virustotal.py
+++ b/modules/sfp_virustotal.py
@@ -21,6 +21,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_virustotal(SpiderFootAsyncPlugin):

--- a/modules/sfp_voipbl.py
+++ b/modules/sfp_voipbl.py
@@ -19,6 +19,10 @@ from netaddr import IPAddress, IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_voipbl(SpiderFootAsyncPlugin):

--- a/modules/sfp_vxvault.py
+++ b/modules/sfp_vxvault.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_vxvault(SpiderFootAsyncPlugin):

--- a/modules/sfp_webanalytics.py
+++ b/modules/sfp_webanalytics.py
@@ -19,6 +19,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_webanalytics(SpiderFootAsyncPlugin):

--- a/modules/sfp_webframework.py
+++ b/modules/sfp_webframework.py
@@ -18,6 +18,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 regexps = dict({
     "jQuery": list(['jquery']),  # unlikely false positive

--- a/modules/sfp_webserver.py
+++ b/modules/sfp_webserver.py
@@ -20,6 +20,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_webserver(SpiderFootAsyncPlugin):

--- a/modules/sfp_wechat.py
+++ b/modules/sfp_wechat.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_wechat(SpiderFootAsyncPlugin):
     """Monitors WeChat for new messages and emits events."""

--- a/modules/sfp_whatcms.py
+++ b/modules/sfp_whatcms.py
@@ -20,6 +20,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_whatcms(SpiderFootAsyncPlugin):

--- a/modules/sfp_whatsapp.py
+++ b/modules/sfp_whatsapp.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_whatsapp(SpiderFootAsyncPlugin):
     """Monitors WhatsApp for new messages and emits events."""

--- a/modules/sfp_whois.py
+++ b/modules/sfp_whois.py
@@ -21,6 +21,10 @@ import whois
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_whois(SpiderFootAsyncPlugin):

--- a/modules/sfp_whoisfreaks.py
+++ b/modules/sfp_whoisfreaks.py
@@ -18,6 +18,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_whoisfreaks(SpiderFootAsyncPlugin):

--- a/modules/sfp_whoisology.py
+++ b/modules/sfp_whoisology.py
@@ -18,6 +18,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_whoisology(SpiderFootAsyncPlugin):

--- a/modules/sfp_whoxy.py
+++ b/modules/sfp_whoxy.py
@@ -18,6 +18,10 @@ import json
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_whoxy(SpiderFootAsyncPlugin):

--- a/modules/sfp_wificafespots.py
+++ b/modules/sfp_wificafespots.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_wificafespots(SpiderFootAsyncPlugin):
     """Queries WiFiCafeSpots.com for public WiFi hotspots and related info."""

--- a/modules/sfp_wifimapio.py
+++ b/modules/sfp_wifimapio.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_wifimapio(SpiderFootAsyncPlugin):
     """Queries WiFiMap.io for public WiFi hotspots and related info."""

--- a/modules/sfp_wigle.py
+++ b/modules/sfp_wigle.py
@@ -20,6 +20,10 @@ import urllib.parse
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_wigle(SpiderFootAsyncPlugin):

--- a/modules/sfp_wikileaks.py
+++ b/modules/sfp_wikileaks.py
@@ -19,6 +19,10 @@ from urllib.parse import urlparse
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_wikileaks(SpiderFootAsyncPlugin):

--- a/modules/sfp_wikipediaedits.py
+++ b/modules/sfp_wikipediaedits.py
@@ -22,6 +22,10 @@ from html.parser import HTMLParser
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_wikipediaedits(SpiderFootAsyncPlugin):

--- a/modules/sfp_xforce.py
+++ b/modules/sfp_xforce.py
@@ -24,6 +24,10 @@ from netaddr import IPNetwork
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_xforce(SpiderFootAsyncPlugin):

--- a/modules/sfp_xiaohongshu.py
+++ b/modules/sfp_xiaohongshu.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 class sfp_xiaohongshu(SpiderFootAsyncPlugin):
     """Monitors Xiaohongshu for new posts and emits events."""

--- a/modules/sfp_yandexdns.py
+++ b/modules/sfp_yandexdns.py
@@ -19,6 +19,10 @@ import dns.resolver
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_yandexdns(SpiderFootAsyncPlugin):

--- a/modules/sfp_zetalytics.py
+++ b/modules/sfp_zetalytics.py
@@ -19,6 +19,10 @@ from urllib.parse import urlencode
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_zetalytics(SpiderFootAsyncPlugin):

--- a/modules/sfp_zonefiles.py
+++ b/modules/sfp_zonefiles.py
@@ -19,6 +19,10 @@ import time
 
 from spiderfoot import SpiderFootEvent, SpiderFootHelpers
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_zonefiles(SpiderFootAsyncPlugin):

--- a/modules/sfp_zoneh.py
+++ b/modules/sfp_zoneh.py
@@ -19,6 +19,10 @@ import re
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_zoneh(SpiderFootAsyncPlugin):

--- a/modules/sfp_zoomeye.py
+++ b/modules/sfp_zoomeye.py
@@ -20,6 +20,10 @@ import requests
 
 from spiderfoot import SpiderFootEvent
 from spiderfoot.plugins.async_plugin import SpiderFootAsyncPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFoot
 
 
 class sfp_zoomeye(SpiderFootAsyncPlugin):

--- a/spiderfoot/__init__.py
+++ b/spiderfoot/__init__.py
@@ -87,7 +87,6 @@ def get_modules_path() -> str:
     return os.path.join(PROJECT_ROOT, "modules")
 
 import importlib.util
-from .helpers import SpiderFootHelpers
 
 # Module import hook removed — loadModules() handles discovery via importlib
 

--- a/spiderfoot/auth/rbac.py
+++ b/spiderfoot/auth/rbac.py
@@ -350,7 +350,7 @@ def require_permission(permission: str):
     """
     from fastapi import Depends, HTTPException, Request
 
-    enforce = os.environ.get("SF_RBAC_ENFORCE", "false").lower() in ("true", "1", "yes")
+    enforce = os.environ.get("SF_RBAC_ENFORCE", "true").lower() in ("true", "1", "yes")
 
     async def _check(request: Request) -> UserContext:
         # Try to get user context from request state (set by auth middleware)
@@ -392,7 +392,7 @@ def require_permission(permission: str):
 
 def get_rbac_summary() -> dict[str, Any]:
     """Return the full RBAC configuration summary."""
-    enforce = os.environ.get("SF_RBAC_ENFORCE", "false").lower() in ("true", "1", "yes")
+    enforce = os.environ.get("SF_RBAC_ENFORCE", "true").lower() in ("true", "1", "yes")
     return {
         "enforced": enforce,
         "default_role": DEFAULT_ROLE,

--- a/spiderfoot/auth/routes.py
+++ b/spiderfoot/auth/routes.py
@@ -492,7 +492,7 @@ async def revoke_session(session_id: str, request: Request):
         raise HTTPException(status_code=401, detail="Not authenticated")
 
     svc = _get_auth_svc()
-    if not svc.revoke_session(session_id):
+    if not svc.revoke_session(session_id, user_id=user.user_id):
         raise HTTPException(status_code=404, detail="Session not found")
     return {"message": "Session revoked"}
 

--- a/spiderfoot/auth/service.py
+++ b/spiderfoot/auth/service.py
@@ -819,14 +819,26 @@ class AuthService:
             for r in cur.fetchall()
         ]
 
-    def revoke_session(self, session_id: str) -> bool:
-        """Revoke a specific session."""
+    def revoke_session(self, session_id: str, user_id: str | None = None) -> bool:
+        """Revoke a specific session.
+
+        When ``user_id`` is provided, the session is only revoked if it
+        belongs to that user, preventing one user from revoking another
+        user's session by guessing/leaking its id.
+        """
         conn = self._get_conn()
         cur = conn.cursor()
-        cur.execute(
-            f"UPDATE tbl_sessions SET is_active = {self._ph()} WHERE id = {self._ph()}",
-            (False, session_id),
-        )
+        if user_id is not None:
+            cur.execute(
+                f"UPDATE tbl_sessions SET is_active = {self._ph()} "
+                f"WHERE id = {self._ph()} AND user_id = {self._ph()}",
+                (False, session_id, user_id),
+            )
+        else:
+            cur.execute(
+                f"UPDATE tbl_sessions SET is_active = {self._ph()} WHERE id = {self._ph()}",
+                (False, session_id),
+            )
         conn.commit()
         return cur.rowcount > 0
 

--- a/spiderfoot/auth/service.py
+++ b/spiderfoot/auth/service.py
@@ -382,8 +382,17 @@ class AuthService:
         )
 
     def token_to_user_context(self, token: str) -> UserContext:
-        """Decode a JWT and return a UserContext."""
+        """Decode a JWT access token and return a UserContext.
+
+        Rejects any token that is not an access token (e.g. a refresh
+        token) so a long-lived refresh token cannot be presented directly
+        as a bearer credential.
+        """
         payload = self.validate_token(token)
+        if payload.get("type") != "access":
+            raise jwt.InvalidTokenError(
+                f"Expected an access token, got type={payload.get('type')!r}"
+            )
         role = parse_role(payload.get("role", "viewer"))
         return UserContext(
             user_id=payload.get("sub", ""),

--- a/spiderfoot/auth/sso.py
+++ b/spiderfoot/auth/sso.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import time
 import uuid
 from dataclasses import dataclass, field, asdict

--- a/spiderfoot/data_service/local.py
+++ b/spiderfoot/data_service/local.py
@@ -12,6 +12,10 @@ import time
 from typing import Any
 
 from spiderfoot.data_service.base import DataService, DataServiceConfig
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFootDb
 
 
 class LocalDataService(DataService):

--- a/spiderfoot/events/event.py
+++ b/spiderfoot/events/event.py
@@ -458,7 +458,7 @@ class SpiderFootEvent:
         Returns:
             Creation timestamp
         """
-        return self.created
+        return self.generated
 
     def getHash(self) -> str:
         """Get event hash.
@@ -474,7 +474,7 @@ class SpiderFootEvent:
         Returns:
             Event data
         """
-        return self.eventData
+        return self.data
 
     def getType(self) -> str:
         """Get event type.

--- a/spiderfoot/plugins/plugin.py
+++ b/spiderfoot/plugins/plugin.py
@@ -136,7 +136,6 @@ class SpiderFootPlugin:
     _scanId = None
     _sharedThreadPool = None
     _thread = None
-    running = False
     maxThreads = 10  # Default maximum threads for this module
 
     # Database and listeners

--- a/spiderfoot/plugins/plugin.py
+++ b/spiderfoot/plugins/plugin.py
@@ -418,7 +418,7 @@ class SpiderFootPlugin:
 
         # Be strict about what events to pass on, unless they are
         # the ROOT event or the event type of the target.
-        if self.__outputFilter__ and eventName not in ['ROOT', self.getTarget().targetType, self.__outputFilter__]:
+        if self.__outputFilter__ and eventName not in ['ROOT', self.getTarget().targetType, *self.__outputFilter__]:
             return
 
         storeOnly = False  # Under some conditions, only store and don't notify
@@ -480,13 +480,14 @@ class SpiderFootPlugin:
                 except Exception as e:
                     self.sf.error(
                         f"Module ({listener.__module__}) encountered an error: {e}")
-                    # set errorState
-                    self.errorState = True
-                    # clear incoming queue
-                    if self.incomingEventQueue:
+                    # Mark the listener that raised as errored (not the
+                    # producing module) so it stops receiving further events.
+                    listener.errorState = True
+                    # clear the failed listener's incoming queue
+                    if listener.incomingEventQueue:
                         with suppress(queue.Empty):
                             while 1:
-                                self.incomingEventQueue.get_nowait()
+                                listener.incomingEventQueue.get_nowait()
 
     def checkForStop(self) -> bool:
         """For modules to use to check for when they should give back control.

--- a/spiderfoot/plugins/plugin.py
+++ b/spiderfoot/plugins/plugin.py
@@ -41,6 +41,10 @@ from ..scan.scan_state_map import (
     DB_STATUS_ABORT_REQUESTED,
     DB_STATUS_FINISHED,
 )
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFootDb, SpiderFootTarget
 
 # begin logging overrides
 # these are copied from the python logging module

--- a/spiderfoot/plugins/plugin_test.py
+++ b/spiderfoot/plugins/plugin_test.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 import importlib
 import logging
 import re
-import types
 from dataclasses import dataclass, field
 from typing import Any, Callable
 

--- a/spiderfoot/scan/scan_coordinator.py
+++ b/spiderfoot/scan/scan_coordinator.py
@@ -421,8 +421,11 @@ class ScanCoordinator:
             if a.retries <= a.work.max_retries:
                 # Retry on a different node
                 a.state = WorkState.REASSIGNED
+                failed_node_id = a.node_id
                 a.node_id = None
-                node = self._select_node(a.work, exclude={a.node_id} if a.node_id else set())
+                node = self._select_node(
+                    a.work, exclude={failed_node_id} if failed_node_id else set()
+                )
                 if node:
                     self._assign(a, node)
                 else:

--- a/spiderfoot/scan/scan_event_bridge.py
+++ b/spiderfoot/scan/scan_event_bridge.py
@@ -45,6 +45,10 @@ import threading
 import time
 from collections import defaultdict
 from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot.events.event_relay import EventRelay
 
 log = logging.getLogger("spiderfoot.scan_event_bridge")
 

--- a/spiderfoot/scan/scan_service_facade.py
+++ b/spiderfoot/scan/scan_service_facade.py
@@ -25,6 +25,10 @@ from .scan_state import (
 )
 from .scan_state_map import db_status_to_state, state_to_db_status
 from .scan_metadata_service import ScanMetadataService
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFootDb
 
 log = logging.getLogger("spiderfoot.scan_service_facade")
 

--- a/spiderfoot/scan/scanner.py
+++ b/spiderfoot/scan/scanner.py
@@ -576,6 +576,7 @@ class SpiderFootScanner():
 
         except Exception as e:
             self.__sf.error(f"Scan [{self.__scanId}] failed: {str(e)}")
+            self.__setStatus(DB_STATUS_ERROR_FAILED, None, time.time() * 1000)
 
         finally:
             scan_end_time = time.time()

--- a/spiderfoot/scan/worker_pool.py
+++ b/spiderfoot/scan/worker_pool.py
@@ -275,10 +275,12 @@ class WorkerPool:
 
     def start(self) -> None:
         """Start the worker pool and all registered workers."""
-        if self._running:
-            return
-
         with self._lock:
+            # Re-check under the lock so two concurrent start() calls cannot
+            # both build an executor and orphan the first one.
+            if self._running:
+                return
+
             max_workers = self.config.effective_max_workers
 
             if self.config.strategy == PoolStrategy.THREAD:

--- a/spiderfoot/security/auth.py
+++ b/spiderfoot/security/auth.py
@@ -325,7 +325,6 @@ class AuthGuard:
 
     def _check_basic_auth(self, headers: dict[str, str]) -> AuthResult:
         """Validate Basic auth credentials."""
-        import base64
 
         auth_header = headers.get("Authorization", "")
         if not auth_header.startswith("Basic "):

--- a/spiderfoot/security/security_middleware.py
+++ b/spiderfoot/security/security_middleware.py
@@ -442,7 +442,6 @@ class FastAPISecurityMiddleware:
     def _create_error_response(self, status_code: int, message: str):
         """Create error response."""
         from fastapi import Response
-        import json
 
         content = json.dumps({
             'error': message,

--- a/spiderfoot/sflib/core.py
+++ b/spiderfoot/sflib/core.py
@@ -34,6 +34,11 @@ from .helpers import (
     hostDomain, validHost, isDomain, validIP, validIP6,
     validIpNetwork, isPublicIpAddress, normalizeDNS,
 )
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spiderfoot import SpiderFootDb
+    import requests
 
 class SpiderFoot:
     """Central facade for SpiderFoot scan operations.

--- a/spiderfoot/sflib/network.py
+++ b/spiderfoot/sflib/network.py
@@ -115,14 +115,26 @@ def safeSocket(host: str, port: int, timeout: int) -> 'ssl.SSLSocket':
     return sock
 
 def safeSSLSocket(host: str, port: int, timeout: int) -> 'ssl.SSLSocket':
-    """Create a TLS-wrapped socket connection with a timeout."""
+    """Create a TLS-wrapped socket connection with a timeout.
+
+    Certificate verification is disabled on purpose: scan targets routinely
+    present self-signed, expired or hostname-mismatched certificates, and
+    this helper exists to inspect them (see sfp_sslcert). A verifying context
+    would refuse to connect to exactly those hosts.
+    """
     context = ssl.create_default_context()
     context.minimum_version = ssl.TLSVersion.TLSv1_2
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
     s = socket.socket()
     s.settimeout(int(timeout))
-    s.connect((host, int(port)))
-    sock = context.wrap_socket(s, server_hostname=host)
-    sock.do_handshake()
+    try:
+        s.connect((host, int(port)))
+        sock = context.wrap_socket(s, server_hostname=host)
+        sock.do_handshake()
+    except Exception:
+        s.close()
+        raise
     return sock
 
 def parseCert(rawcert: str, fqdn: str | None = None, expiringdays: int = 30) -> dict:

--- a/spiderfoot/threadpool.py
+++ b/spiderfoot/threadpool.py
@@ -243,7 +243,9 @@ class SpiderFootThreadPool:
         except AttributeError:
             inputThreadAlive = False
 
-        inputQueuesEmpty = [q.empty() for q in self.inputQueues.values()]
+        # Snapshot the values so a concurrent submit() adding a new task
+        # queue cannot trigger "dictionary changed size during iteration".
+        inputQueuesEmpty = [q.empty() for q in list(self.inputQueues.values())]
         return not inputThreadAlive and all(inputQueuesEmpty) and all(finishedThreads)
 
     def __enter__(self) -> SpiderFootThreadPool:

--- a/test/unit/modules/test_sfp__stor_db.py
+++ b/test/unit/modules/test_sfp__stor_db.py
@@ -211,21 +211,6 @@ class TestModuleStor_db(TestModuleBase):
         module = sfp__stor_db()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_postgresql_storage(self):
-        """Test PostgreSQL storage functionality."""
-        module = sfp__stor_db()
-        module.setup(self.sf_instance, {'_store': True, 'db_type': 'postgresql'})
-        
-        # Create test event
-        test_event = self.create_test_event()
-        
-        # Mock getScanId
-        module.getScanId = MagicMock(return_value="test_scan_id")
-        
-        module.handleEvent(test_event)
-        
-        # Verify that scanEventStore was called
-        self.mock_dbh.scanEventStore.assert_called()
 
     @patch('modules.sfp__stor_db.psycopg2.connect')
     def test_postgresql_storage_with_size_limit(self, mock_connect):

--- a/test/unit/modules/test_sfp_abstractapi.py
+++ b/test/unit/modules/test_sfp_abstractapi.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleAbstractapi(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_abstractapi()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_abuseipdb.py
+++ b/test/unit/modules/test_sfp_abuseipdb.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleAbuseipdb(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_abuseipdb()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_alienvault.py
+++ b/test/unit/modules/test_sfp_alienvault.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleAlienvault(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_alienvault()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_archiveorg_extended.py
+++ b/test/unit/modules/test_sfp_archiveorg_extended.py
@@ -52,7 +52,6 @@ class TestModuleArchiveorgExtended(TestModuleBase):
             # Re-instantiate plugin for each event type to reset results
             module = sfp_archiveorg()
             module.setup(self.sf, self.default_opts)
-            mock_notify = None
             evt = SpiderFootEvent(event_type, 'example.com', 'sfp_archiveorg', None)
             self.sf.fetchUrl = MagicMock(return_value=fake_response)
             with patch.object(module, 'notifyListeners') as mock_notify:

--- a/test/unit/modules/test_sfp_binaryedge.py
+++ b/test/unit/modules/test_sfp_binaryedge.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleBinaryedge(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_binaryedge()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_bingsearch.py
+++ b/test/unit/modules/test_sfp_bingsearch.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleBingsearch(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_bingsearch()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_bingsharedip.py
+++ b/test/unit/modules/test_sfp_bingsharedip.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleBingsharedip(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_bingsharedip()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_bitcoin.py
+++ b/test/unit/modules/test_sfp_bitcoin.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleBitcoin(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_bitcoin()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_bitcoinwhoswho.py
+++ b/test/unit/modules/test_sfp_bitcoinwhoswho.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 
 class TestModuleBitcoinwhoswho(TestModuleBase):
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_bitcoinwhoswho()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_botscout.py
+++ b/test/unit/modules/test_sfp_botscout.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleBotscout(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_botscout()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_builtwith.py
+++ b/test/unit/modules/test_sfp_builtwith.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 
 class TestModulebuiltwith(TestModuleBase):
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_builtwith()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_c99.py
+++ b/test/unit/modules/test_sfp_c99.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 
 class TestModuleC99(TestModuleBase):
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_c99()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_censys.py
+++ b/test/unit/modules/test_sfp_censys.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 
 class TestModuleCensys(TestModuleBase):
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_censys()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_certspotter.py
+++ b/test/unit/modules/test_sfp_certspotter.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleiCertspotter(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_certspotter()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_circllu.py
+++ b/test/unit/modules/test_sfp_circllu.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleCircllu(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_circllu()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_cisco_umbrella.py
+++ b/test/unit/modules/test_sfp_cisco_umbrella.py
@@ -74,6 +74,3 @@ class TestModuleCiscoUmbrella(TestModuleBase):
     def tearDown(self):
         """Clean up after each test."""
         super().tearDown()
-    def tearDown(self):
-        """Clean up after each test."""
-        super().tearDown()

--- a/test/unit/modules/test_sfp_company.py
+++ b/test/unit/modules/test_sfp_company.py
@@ -13,15 +13,8 @@ from test.unit.utils.test_module_base import TestModuleBase
 class TestModuleCompany(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_company()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_cookie.py
+++ b/test/unit/modules/test_sfp_cookie.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleCookie(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_cookie()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_countryname.py
+++ b/test/unit/modules/test_sfp_countryname.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleCountryName(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_countryname()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_creditcard.py
+++ b/test/unit/modules/test_sfp_creditcard.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleCreditCard(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_creditcard()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_crt.py
+++ b/test/unit/modules/test_sfp_crt.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleCrt(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_crt()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_customfeed.py
+++ b/test/unit/modules/test_sfp_customfeed.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleCustomfeed(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_customfeed()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_dehashed.py
+++ b/test/unit/modules/test_sfp_dehashed.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 
 class TestModuleDehashed(TestModuleBase):
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_dehashed()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_email.py
+++ b/test/unit/modules/test_sfp_email.py
@@ -13,15 +13,8 @@ from test.unit.utils.test_module_base import TestModuleBase
 class TestModuleEmail(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_email()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_emailcrawlr.py
+++ b/test/unit/modules/test_sfp_emailcrawlr.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleEmailcrawlr(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_emailcrawlr()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_errors.py
+++ b/test/unit/modules/test_sfp_errors.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleErrors(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_errors()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_etherscan.py
+++ b/test/unit/modules/test_sfp_etherscan.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 
 class TestModuleEtherscan(TestModuleBase):
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_etherscan()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_focsec.py
+++ b/test/unit/modules/test_sfp_focsec.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleFocsec(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_focsec()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_fraudguard.py
+++ b/test/unit/modules/test_sfp_fraudguard.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleFraudguard(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_fraudguard()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_fullcontact.py
+++ b/test/unit/modules/test_sfp_fullcontact.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 
 class TestModuleFullcontact(TestModuleBase):
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_fullcontact()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_fullhunt.py
+++ b/test/unit/modules/test_sfp_fullhunt.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleFullhunt(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_fullhunt()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_github.py
+++ b/test/unit/modules/test_sfp_github.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 
 class TestModuleGithub(TestModuleBase):
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_github()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_gleif.py
+++ b/test/unit/modules/test_sfp_gleif.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleGleif(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_gleif()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_googlemaps.py
+++ b/test/unit/modules/test_sfp_googlemaps.py
@@ -18,15 +18,8 @@ class TestModuleGoogleMaps(TestModuleBase):
     """
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_googlemaps()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_googlesafebrowsing.py
+++ b/test/unit/modules/test_sfp_googlesafebrowsing.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleGoogleSafebrowsing(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_googlesafebrowsing()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_googlesearch.py
+++ b/test/unit/modules/test_sfp_googlesearch.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleGoogleSearch(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_googlesearch()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_grayhatwarfare.py
+++ b/test/unit/modules/test_sfp_grayhatwarfare.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 
 class TestModuleGrayhatWarfare(TestModuleBase):
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_grayhatwarfare()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_greynoise.py
+++ b/test/unit/modules/test_sfp_greynoise.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleGreynoise(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_greynoise()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_hashes.py
+++ b/test/unit/modules/test_sfp_hashes.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleHashes(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_hashes()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_haveibeenpwned.py
+++ b/test/unit/modules/test_sfp_haveibeenpwned.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleHaveibeenpwned(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_haveibeenpwned()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_honeypot.py
+++ b/test/unit/modules/test_sfp_honeypot.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 
 class TestModuleHoneypot(TestModuleBase):
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_honeypot()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_hostio.py
+++ b/test/unit/modules/test_sfp_hostio.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleHostio(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_hostio()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_hunter.py
+++ b/test/unit/modules/test_sfp_hunter.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleHunter(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_hunter()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_hybrid_analysis.py
+++ b/test/unit/modules/test_sfp_hybrid_analysis.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleHybridAnalysis(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_hybrid_analysis()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_iban.py
+++ b/test/unit/modules/test_sfp_iban.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleIban(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_iban()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_iknowwhatyoudownload.py
+++ b/test/unit/modules/test_sfp_iknowwhatyoudownload.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleIknowwhatyoudownload(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_iknowwhatyoudownload()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_intelx.py
+++ b/test/unit/modules/test_sfp_intelx.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleIntelx(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_intelx()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_intfiles.py
+++ b/test/unit/modules/test_sfp_intfiles.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleIntfiles(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_intfiles()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_ipapicom.py
+++ b/test/unit/modules/test_sfp_ipapicom.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleipapicom(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_ipapicom()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_ipinfo.py
+++ b/test/unit/modules/test_sfp_ipinfo.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleIpinfo(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_ipinfo()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_ipqualityscore.py
+++ b/test/unit/modules/test_sfp_ipqualityscore.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleIpqualityscore(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_ipqualityscore()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_ipregistry.py
+++ b/test/unit/modules/test_sfp_ipregistry.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleIpRegistry(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_ipregistry()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_ipstack.py
+++ b/test/unit/modules/test_sfp_ipstack.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleIpstack(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_ipstack()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_jsonwhoiscom.py
+++ b/test/unit/modules/test_sfp_jsonwhoiscom.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleJsonwhoiscom(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_jsonwhoiscom()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_koodous.py
+++ b/test/unit/modules/test_sfp_koodous.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleKoodous(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_koodous()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_leakix.py
+++ b/test/unit/modules/test_sfp_leakix.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleLeakix(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_leakix()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_malwarepatrol.py
+++ b/test/unit/modules/test_sfp_malwarepatrol.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModulemalwarepatrol(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_malwarepatrol()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_metadefender.py
+++ b/test/unit/modules/test_sfp_metadefender.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleMetadefender(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_metadefender()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_myspace.py
+++ b/test/unit/modules/test_sfp_myspace.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleMyspace(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_myspace()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_nameapi.py
+++ b/test/unit/modules/test_sfp_nameapi.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 
 class TestModuleNameapi(TestModuleBase):
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_producedEvents_should_return_list(self):
         """
         Test producedEvents(self)

--- a/test/unit/modules/test_sfp_names.py
+++ b/test/unit/modules/test_sfp_names.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleNames(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_names()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_netlas.py
+++ b/test/unit/modules/test_sfp_netlas.py
@@ -46,33 +46,6 @@ class TestModuleNetlas(TestModuleBase):
         self.assertEqual(module.watchedEvents(), [
                          "DOMAIN_NAME", "IP_ADDRESS", "IPV6_ADDRESS"])
 
-    @patch('modules.sfp_netlas.sfp_netlas.queryNetlas')
-    def test_handleEvent(self, mock_queryNetlas):
-        module = sfp_netlas()
-        module.setup(self.sf, dict())
-
-        target_value = 'example.com'
-        target_type = 'INTERNET_NAME'
-        target = SpiderFootTarget(target_value, target_type)
-        module.setTarget(target)
-
-        event_type = 'ROOT'
-        event_data = 'example data'
-        event_module = ''
-        source_event = ''
-        evt = SpiderFootEvent(event_type, event_data,
-                              event_module, source_event)
-
-        mock_queryNetlas.return_value = None
-        result = module.handleEvent(evt)
-        self.assertIsNone(result)
-
-        mock_queryNetlas.return_value = {'geoinfo': 'example geoinfo'}
-        result = module.handleEvent(evt)
-        self.assertIsNone(result)
-        self.assertEqual(len(module.sf.events), 1)
-        self.assertEqual(module.sf.events[0].eventType, 'GEOINFO')
-        self.assertEqual(module.sf.events[0].data, 'example geoinfo')
 
     def tearDown(self):
         """Clean up after each test."""

--- a/test/unit/modules/test_sfp_networksdb.py
+++ b/test/unit/modules/test_sfp_networksdb.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleNetworksdb(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_networksdb()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_neutrinoapi.py
+++ b/test/unit/modules/test_sfp_neutrinoapi.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleNeutrinoapi(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_neutrinoapi()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_numverify.py
+++ b/test/unit/modules/test_sfp_numverify.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleNumverify(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_numverify()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_onioncity.py
+++ b/test/unit/modules/test_sfp_onioncity.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleonioncity(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_onioncity()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_onyphe.py
+++ b/test/unit/modules/test_sfp_onyphe.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleOnyphe(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_onyphe()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_pastebin.py
+++ b/test/unit/modules/test_sfp_pastebin.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModulePastebin(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_pastebin()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_pgp.py
+++ b/test/unit/modules/test_sfp_pgp.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModulePgp(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_pgp()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_projectdiscovery.py
+++ b/test/unit/modules/test_sfp_projectdiscovery.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleProjectdiscovery(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_projectdiscovery()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_pulsedive.py
+++ b/test/unit/modules/test_sfp_pulsedive.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModulePulsedive(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_pulsedive()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_securitytrails.py
+++ b/test/unit/modules/test_sfp_securitytrails.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleSecuritytrails(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_securitytrails()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_seon.py
+++ b/test/unit/modules/test_sfp_seon.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleSeon(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_seon()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_shodan.py
+++ b/test/unit/modules/test_sfp_shodan.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleShodan(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_shodan()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_slideshare.py
+++ b/test/unit/modules/test_sfp_slideshare.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleSlideshare(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_slideshare()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_snov.py
+++ b/test/unit/modules/test_sfp_snov.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleSnov(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_snov()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_social.py
+++ b/test/unit/modules/test_sfp_social.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleSocial(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_social()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_sociallinks.py
+++ b/test/unit/modules/test_sfp_sociallinks.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleSociallinks(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_sociallinks()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_socialprofiles.py
+++ b/test/unit/modules/test_sfp_socialprofiles.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleSocialprofiles(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_socialprofiles()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_spur.py
+++ b/test/unit/modules/test_sfp_spur.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleSpur(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_spur()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_strangeheaders.py
+++ b/test/unit/modules/test_sfp_strangeheaders.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleStrangeHeaders(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_strangeheaders()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_textmagic.py
+++ b/test/unit/modules/test_sfp_textmagic.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleTextmagic(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_textmagic()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_tool_cmseek.py
+++ b/test/unit/modules/test_sfp_tool_cmseek.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleToolCmseek(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_tool_cmseek()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_tool_nbtscan.py
+++ b/test/unit/modules/test_sfp_tool_nbtscan.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleToolNbtscan(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_tool_nbtscan()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_tool_onesixtyone.py
+++ b/test/unit/modules/test_sfp_tool_onesixtyone.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleToolOnesixtyone(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_tool_onesixtyone()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_tool_retirejs.py
+++ b/test/unit/modules/test_sfp_tool_retirejs.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleToolRetirejs(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_tool_retirejs()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_tool_snallygaster.py
+++ b/test/unit/modules/test_sfp_tool_snallygaster.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleToolSnallygaster(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_tool_snallygaster()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_tool_testsslsh.py
+++ b/test/unit/modules/test_sfp_tool_testsslsh.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleToolTestsslsh(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_tool_testsslsh()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_tool_trufflehog.py
+++ b/test/unit/modules/test_sfp_tool_trufflehog.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleToolTrufflehog(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_tool_trufflehog()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_tool_wafw00f.py
+++ b/test/unit/modules/test_sfp_tool_wafw00f.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleToolWafw00f(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_tool_wafw00f()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_tool_wappalyzer.py
+++ b/test/unit/modules/test_sfp_tool_wappalyzer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pytest
 import unittest
-from test.unit.utils.test_module_base import TestModuleBase
 from unittest.mock import patch, MagicMock
 
 from modules.sfp_tool_wappalyzer import sfp_tool_wappalyzer

--- a/test/unit/modules/test_sfp_tool_whatweb.py
+++ b/test/unit/modules/test_sfp_tool_whatweb.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleToolWhatweb(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_tool_whatweb()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_twilio.py
+++ b/test/unit/modules/test_sfp_twilio.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuletwilio(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_twilio()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_twitter.py
+++ b/test/unit/modules/test_sfp_twitter.py
@@ -16,15 +16,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleTwitter(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_twitter()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_viewdns.py
+++ b/test/unit/modules/test_sfp_viewdns.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModulViewdns(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_viewdns()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_virustotal.py
+++ b/test/unit/modules/test_sfp_virustotal.py
@@ -16,15 +16,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleVirustotal(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_virustotal()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_webanalytics.py
+++ b/test/unit/modules/test_sfp_webanalytics.py
@@ -16,15 +16,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleWebAnalytics(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_webanalytics()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_webframework.py
+++ b/test/unit/modules/test_sfp_webframework.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleWebFramework(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_webframework()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_whatcms.py
+++ b/test/unit/modules/test_sfp_whatcms.py
@@ -16,15 +16,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleWhatCMS(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_whatcms()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_whoisology.py
+++ b/test/unit/modules/test_sfp_whoisology.py
@@ -16,15 +16,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleWhoisology(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_whoisology()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_whoxy.py
+++ b/test/unit/modules/test_sfp_whoxy.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleWhoxy(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_whoxy()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_wigle.py
+++ b/test/unit/modules/test_sfp_wigle.py
@@ -16,15 +16,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleWigle(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_wigle()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_xforce.py
+++ b/test/unit/modules/test_sfp_xforce.py
@@ -16,15 +16,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleXforce(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_xforce()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_zetalytics.py
+++ b/test/unit/modules/test_sfp_zetalytics.py
@@ -15,15 +15,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleZetalytics(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_zetalytics()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_zonefiles.py
+++ b/test/unit/modules/test_sfp_zonefiles.py
@@ -14,15 +14,8 @@ from test.unit.utils.test_helpers import safe_recursion
 class TestModuleZoneFiles(TestModuleBase):
 
 
-    def setUp(self):
-        """Enhanced setUp with ThreadReaper module tracking."""
-        super().setUp()
         # ThreadReaper infrastructure is automatically initialized
         
-    def tearDown(self):
-        """Enhanced tearDown with ThreadReaper cleanup."""
-        # ThreadReaper infrastructure automatically cleans up
-        super().tearDown()
     def test_opts(self):
         module = sfp_zonefiles()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/spiderfoot/test_spiderfootevent.py
+++ b/test/unit/spiderfoot/test_spiderfootevent.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 """Tests for spiderfootevent module."""
 
 import unittest
-from test.unit.utils.test_module_base import TestModuleBase
 from spiderfoot.events.event import SpiderFootEvent
 from test.unit.utils.test_base import TestModuleBase
 from test.unit.utils.resource_manager import get_test_resource_manager

--- a/test/unit/spiderfoot/test_spiderfoothelpers.py
+++ b/test/unit/spiderfoot/test_spiderfoothelpers.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 """Tests for spiderfoothelpers module."""
 
 import unittest
-from test.unit.utils.test_module_base import TestModuleBase
 from unittest.mock import patch, MagicMock, mock_open
 from spiderfoot.helpers import SpiderFootHelpers
 from test.unit.utils.test_base import TestModuleBase
@@ -172,7 +171,7 @@ class TestSpiderFootHelpers(TestModuleBase):
 
     def test_dictionaryWordsFromWordlists(self):
         import importlib
-        from unittest.mock import patch, mock_open, MagicMock
+        from unittest.mock import patch, MagicMock
         with patch('spiderfoot.helpers.resources.files') as mock_files:
             mock_joinpath = MagicMock()
             mock_open_file = mock_open(read_data='word1\nword2\nword3')()
@@ -187,7 +186,7 @@ class TestSpiderFootHelpers(TestModuleBase):
 
     def test_humanNamesFromWordlists(self):
         import importlib
-        from unittest.mock import patch, mock_open, MagicMock
+        from unittest.mock import patch, MagicMock
         with patch('spiderfoot.helpers.resources.files') as mock_files:
             mock_joinpath = MagicMock()
             mock_open_file = mock_open(read_data='name1\nname2\nname3')()
@@ -202,7 +201,7 @@ class TestSpiderFootHelpers(TestModuleBase):
 
     def test_usernamesFromWordlists(self):
         import importlib
-        from unittest.mock import patch, mock_open, MagicMock
+        from unittest.mock import patch, MagicMock
         with patch('spiderfoot.helpers.resources.files') as mock_files:
             mock_joinpath = MagicMock()
             mock_open_file = mock_open(read_data='user1\nuser2\nuser3')()

--- a/test/unit/spiderfoot/test_spiderfootplugin.py
+++ b/test/unit/spiderfoot/test_spiderfootplugin.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 """Tests for spiderfootplugin module."""
 
 import unittest
-from test.unit.utils.test_module_base import TestModuleBase
 from unittest.mock import MagicMock, patch
 from spiderfoot.plugins.plugin import SpiderFootPlugin
 from spiderfoot import SpiderFootEvent, SpiderFootTarget

--- a/test/unit/spiderfoot/test_spiderfoottarget.py
+++ b/test/unit/spiderfoot/test_spiderfoottarget.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 """Tests for spiderfoottarget module."""
 
 import unittest
-from test.unit.utils.test_module_base import TestModuleBase
 from spiderfoot.target import SpiderFootTarget
 from test.unit.utils.test_base import TestModuleBase
 from test.unit.utils.resource_manager import get_test_resource_manager

--- a/test/unit/spiderfoot/test_spiderfootthreadpool.py
+++ b/test/unit/spiderfoot/test_spiderfootthreadpool.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 """Tests for spiderfootthreadpool module."""
 
 import unittest
-from test.unit.utils.test_module_base import TestModuleBase
 from unittest.mock import MagicMock, patch
 from spiderfoot.threadpool import SpiderFootThreadPool, ThreadPoolWorker
 import queue

--- a/test/unit/test_cross_platform_stability.py
+++ b/test/unit/test_cross_platform_stability.py
@@ -294,7 +294,6 @@ sys.exit(0)
 
     def test_thread_safety_during_shutdown(self):
         """Test thread safety during shutdown scenarios."""
-        import threading
         import queue
         
         # Create a queue for thread communication

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import os
 import pytest
 import unittest
-from test.unit.utils.test_module_base import TestModuleBase
 
 from spiderfoot.sflib import SpiderFoot
 from spiderfoot import SpiderFootDb
@@ -209,7 +208,6 @@ class TestSpiderFootModuleLoading(TestModuleBase):
 
     def test_module_watched_events_are_valid(self):
         sf = SpiderFoot(self.default_options)
-        from spiderfoot.db import SpiderFootDb
         valid_events = [e[0] for e in SpiderFootDb.eventDetails]
 
         sfModules = self.load_modules(sf)
@@ -223,7 +221,6 @@ class TestSpiderFootModuleLoading(TestModuleBase):
 
     def test_module_produced_events_are_valid(self):
         sf = SpiderFoot(self.default_options)
-        from spiderfoot.db import SpiderFootDb
         valid_events = [e[0] for e in SpiderFootDb.eventDetails]
 
         sfModules = self.load_modules(sf)

--- a/test/unit/test_report_api.py
+++ b/test/unit/test_report_api.py
@@ -192,7 +192,6 @@ class TestReportStore:
 
 def _make_mock_report(executive_summary="No findings to report."):
     """Create a fake GeneratedReport-like object for tests."""
-    from unittest.mock import MagicMock
     mock_report = MagicMock()
     mock_report.title = "Mock Report"
     mock_report.executive_summary = executive_summary
@@ -323,7 +322,6 @@ class TestAPIEndpoints:
     @pytest.fixture
     def client(self):
         from spiderfoot.api.dependencies import get_scan_service, get_api_key
-        from unittest.mock import MagicMock
         app = FastAPI()
         app.include_router(router, prefix="/api")
         # Override DB-dependent services so tests don't need a real PostgreSQL

--- a/test/unit/test_sflib.py
+++ b/test/unit/test_sflib.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 # test_sflib_comprehensive.py
 import pytest
 import unittest
-from test.unit.utils.test_module_base import TestModuleBase
 import json
 import os
 import tempfile
@@ -216,7 +215,6 @@ class TestSpiderFootComprehensive(TestModuleBase):
     @patch('builtins.open', new_callable=mock_open, read_data='cached content')
     def test_cacheGet_valid_cache(self, mock_file, mock_stat, mock_cache_path):
         """Test cacheGet with valid cache."""
-        import time
         mock_cache_path.return_value = "/tmp/cache"
         mock_stat.return_value.st_size = 100
         mock_stat.return_value.st_mtime = time.time() - 1000  # Recent enough
@@ -228,7 +226,6 @@ class TestSpiderFootComprehensive(TestModuleBase):
     @patch('os.stat')
     def test_cacheGet_expired_cache(self, mock_stat, mock_cache_path):
         """Test cacheGet with expired cache."""
-        import time
         mock_cache_path.return_value = "/tmp/cache"
         mock_stat.return_value.st_size = 100
         mock_stat.return_value.st_mtime = time.time() - 100000  # Too old

--- a/test/unit/test_spiderfoot.py
+++ b/test/unit/test_spiderfoot.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 # test_spiderfoot.py
 import pytest
 import unittest
-from test.unit.utils.test_module_base import TestModuleBase
 
 from spiderfoot.sflib import SpiderFoot
 from test.unit.utils.test_base import TestModuleBase


### PR DESCRIPTION
process_saml_response() and process_oidc_callback() reference
os.environ to gate dev mode but the module never imported os,
so both entry points raised NameError when invoked.